### PR TITLE
[release-2.2] k3d version check

### DIFF
--- a/ci/scripts/k3d.sh
+++ b/ci/scripts/k3d.sh
@@ -1,8 +1,30 @@
 #!/bin/bash
 
-# install k3d 1.7.0
-curl -s https://raw.githubusercontent.com/rancher/k3d/master/install.sh | TAG=v1.7.0 bash
+K3D_VER=v1.7.0
 
+
+CUR_K3D=$($(which k3d) --version | awk '{print $3}')
+
+if [[ "$CUR_K3D" != "$K3D_VER" ]] ; then 
+    if [[ "$CUR_K3D" == "" ]]; then
+    read -p "k3d does not seem to be installed. Would you like to install k3d version: [$K3D_VER]? [Yn] " -n 1 yn
+        case $yn in    
+            [Yy]* ) curl -s https://raw.githubusercontent.com/rancher/k3d/master/install.sh | TAG="$K3D_VER" bash;;
+            [Nn]* ) echo -e "\nNot installing k3d";;
+            * ) echo -e "\n Please answer yes or no.  Bye" && exit 0 ;;
+        esac
+    else
+        read -p "Current k3d version: [$CUR_K3D]. Supported k3d version: [$K3D_VER].  Would you like to change? [Yn] " -n 1 yn
+        case $yn in 
+            [Yy]* ) curl -s https://raw.githubusercontent.com/rancher/k3d/master/install.sh | TAG="$K3D_VER" bash;;
+            [Nn]* ) echo -e "\nContinuing with k3d version [$CUR_K3D]";;
+            * ) echo -e "\n Please answer yes or no.  Default to using your current version [$CUR_K3D]";;
+        esac
+    fi
+fi
+    
+
+echo "Creating k3d cluster"
 k3d create --workers 4 --name greymatter --publish 30000:10808 
 while [[ $(k3d get-kubeconfig --name='greymatter') != *kubeconfig.yaml ]]; do echo "echo waiting for k3d cluster to start up" && sleep 10; done
 export KUBECONFIG="$(k3d get-kubeconfig --name='greymatter')"

--- a/docs/Deploy with K3d.md
+++ b/docs/Deploy with K3d.md
@@ -8,13 +8,12 @@
 ## Local Usage
 
 1. `make k3d` - start a kubernetes cluster locally.
-2. `export KUBECONFIG="$(k3d get-kubeconfig --name='greymatter')"` - configures `kubectl` to use the local k3d cluster.
-3. `make credentials` - creates a git ignored file `credentials.yaml`
-4. `make secrets` - inserts data from `credentials.yaml` and `secrets/values.yaml` into the cluster as secrets
-5. `make install` - installs each helm chart (spire, fabric, edge, data, sense). This will take about 1.5 minutes
-6. Open up <https://localhost:30000> using the certificate `./certs/quickstart.p12`. The password is "password"
-7. When you're ready, uninstall Grey Matter with `make uninstall`
-
+1. `export KUBECONFIG="$(k3d get-kubeconfig --name='greymatter')"` - configures `kubectl` to use the local k3d cluster.
+1. `make credentials` - creates a git ignored file `credentials.yaml` 
+1. `make secrets` - inserts data from `credentials.yaml` and `secrets/values.yaml` into the cluster as secrets.
+1. `make install` installs each helm chart (spire, fabric, edge, data, sense). This will take about 1.5 minutes.
+1. Open up https://localhost:30000 using the certificate `./certs/quickstart.p12`. The password is "password"
+1. When you're ready, uninstall Grey Matter with `make uninstall`
 
 ### Cluster Command
 


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

Add logic around the k3d install script that makes this an interactive tool to avoid changing the users machine if we dont need to.  Closes Issue #578 

2. What **changes to custom.yaml** are required?

none

3. Have you documented any additional setup steps or configurations options?

I added documentation specifying our supported version of k3d as 1.7.0

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

*test a fresh k3d install*
- run `which k3d` and delete or move that file
- run `make k3d` 
- the script will say you do not have it installed and will ask if you want to install 1.7.0
- clean up with `make destroy`

*test with an old version of k3d*
- run `make k3d`
- answer yes to installing or upgrading
- change `K3D_VER` to v1.6.0
- run `make k3d` again
- should print out:  `Current k3d version: [v1.7.0]. Supported k3d version: [v1.6.0].  Would you like to change? [Yn]`
- clean up run `make destroy`, change back `K3D_VER` and run `make k3d` to get back to 2.7.0, then `make destroy` again to shut down cluster

*test current version*
- run `($(which k3d) --version | awk '{print $3}')` to ensure you are on v1.7.0
- run `make k3d`
- you should see `You are currently using the currently supported version of k3d [v1.7.0]`

Thanks for testing! and let me know if you have problems.