### PR TITLE
WIP: configure prometheus ALS in gm-control

### DIFF
--- a/fabric/control/templates/control.yaml
+++ b/fabric/control/templates/control.yaml
@@ -28,6 +28,9 @@ spec:
             - name: grpc
               containerPort: {{ .Values.global.control.port }}
               protocol: TCP
+            - name: als-metrics
+              containerPort: {{ .Values.global.control.prometheus_port }}
+              protocol: TCP
           livenessProbe:
             tcpSocket:
               port: grpc

--- a/fabric/control/values.yaml
+++ b/fabric/control/values.yaml
@@ -97,13 +97,13 @@ control:
     gm_control_kubernetes_namespaces:
       type: 'value'
       value: '{{ include "control.namespaces" . }}'
+    # The following values are not applied. Change the 'type' to 'value' to use these variables.
     gm_control_stats_backends:
-        type: 'value'
+        type: 'null'
         value: 'prometheus'
     gm_control_stats_addr:
-      type: 'value'
+      type: 'null'
       value: '0.0.0.0:{{ .Values.global.control.prometheus_port }}/prometheus'
-    # The following values are not applied. Change the 'type' to 'value' to use these variables.
     gm_control_diff_dry_run:
       type: 'null'
       value: 'true'

--- a/fabric/control/values.yaml
+++ b/fabric/control/values.yaml
@@ -18,6 +18,8 @@ global:
     port: 50000
     # The label Control uses to find pods to include in the mesh
     cluster_label: greymatter.io/control
+    # port for prometheus to listen on
+    prometheus_port: 9102
     # Comma delimited string of namespaces for control to monitor. Also used by prometheus. 
     additional_namespaces:
   # Configures the init container used to wait on various deployments to be ready
@@ -95,6 +97,12 @@ control:
     gm_control_kubernetes_namespaces:
       type: 'value'
       value: '{{ include "control.namespaces" . }}'
+    gm_control_stats_backends:
+        type: 'value'
+        value: 'prometheus'
+    gm_control_stats_addr:
+      type: 'value'
+      value: '0.0.0.0:{{ .Values.global.control.prometheus_port }}/prometheus'
     # The following values are not applied. Change the 'type' to 'value' to use these variables.
     gm_control_diff_dry_run:
       type: 'null'

--- a/fabric/values.yaml
+++ b/fabric/values.yaml
@@ -20,6 +20,8 @@ global:
     port: 50000
     # The label Control uses to find pods to include in the mesh
     cluster_label: greymatter.io/control
+    # port for prometheus to listen on
+    prometheus_port: 9102
     # Comma delimited string of namespaces for control to monitor. Also used by prometheus.    
     additional_namespaces:
   data:
@@ -76,8 +78,8 @@ control:
     # Number of replicas for the deployment
     replicas: 1
     # Version of control
-    version: 1.4.2
-    image: 'docker.production.deciphernow.com/deciphernow/gm-control:{{ $.Values.control.version }}'
+    version: latest
+    image: 'deciphernow/gm-control:{{ $.Values.control.version }}'
     # When to pull images, used in the deployment
     image_pull_policy: IfNotPresent
     # Secret used to talk to control-api
@@ -136,6 +138,12 @@ control:
       gm_control_kubernetes_namespaces:
         type: 'value'
         value: '{{ include "control.namespaces" . }}'
+      gm_control_stats_backends:
+        type: 'value'
+        value: 'prometheus'
+      gm_control_stats_addr:
+        type: 'value'
+        value: '0.0.0.0:9102/prometheus'
       # The following values are not applied. Change the type to 'value' to use these variables.
       gm_control_diff_dry_run:
         type: 'null'

--- a/fabric/values.yaml
+++ b/fabric/values.yaml
@@ -138,13 +138,13 @@ control:
       gm_control_kubernetes_namespaces:
         type: 'value'
         value: '{{ include "control.namespaces" . }}'
+      # The following values are not applied. Change the type to 'value' to use these variables.
       gm_control_stats_backends:
         type: 'value'
         value: 'prometheus'
       gm_control_stats_addr:
         type: 'value'
-        value: '0.0.0.0:9102/prometheus'
-      # The following values are not applied. Change the type to 'value' to use these variables.
+        value: '0.0.0.0:{{ .Values.global.control.prometheus_port }}/prometheus'
       gm_control_diff_dry_run:
         type: 'null'
         value: 'true'

--- a/global.yaml
+++ b/global.yaml
@@ -16,6 +16,8 @@ global:
     port: 50000
     # The label Control uses to find pods to include in the mesh
     cluster_label: greymatter.io/control
+    # port for prometheus to listen on
+    prometheus_port: 9102
     # Comma delimited string of namespaces for control to monitor. Also used by prometheus.
     additional_namespaces:
   data:

--- a/sense/dashboard/templates/prometheus-configmap.yaml
+++ b/sense/dashboard/templates/prometheus-configmap.yaml
@@ -87,6 +87,21 @@ data:
           regex: '(.*):(.*)'
           target_label:  '__address__'
           replacement:   '${1}:8001'
+      - job_name: 'gm-control'
+        metrics_path: /prometheus
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names:
+{{ include "greymatter.dashboard.prometheus_namespaces" . | indent 16 }}
+        relabel_configs:
+        - source_labels: ['__meta_kubernetes_pod_container_port_name']
+          regex: 'als-metrics'
+          action: 'keep'
+        - source_labels: ['__address__']
+          regex: '(.*):(.*)'
+          target_label: '__address__'
+          replacement: '${1}:{{ .Values.global.control.prometheus_port }}'
       {{- end }}
 
   # Copied from https://github.com/DecipherNow/gm-dashboard/blob/master/docker/prometheus/recording_rules.yml

--- a/sense/dashboard/values.yaml
+++ b/sense/dashboard/values.yaml
@@ -18,6 +18,8 @@ global:
     port: 50000
     # The label Control uses to find pods to include in the mesh
     cluster_label: greymatter.io/control
+    # port for prometheus to listen on
+    prometheus_port: 9102
     # Comma delimited string of namespaces for control to monitor. Also used by prometheus.    
     additional_namespaces:   
   # Whether or not to use spire for cert management and the trust domain

--- a/sense/values.yaml
+++ b/sense/values.yaml
@@ -18,6 +18,8 @@ global:
     port: 50000
     # The label Control uses to find pods to include in the mesh
     cluster_label: greymatter.io/control
+    # port for prometheus to listen on
+    prometheus_port: 9102
     # Comma delimited string of namespaces for control to monitor. Also used by prometheus.    
     additional_namespaces:   
   data:


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

resolves #680
<br/><br/>

2. What **changes to custom.yaml** are required?

Added global.control.prometheus_port to configure a port for the prometheus client to listen on.
<br/><br/>

3. Have you documented any additional setup steps or configurations options?

prometheus_port
<br/><br/>

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

To test:

`helm install` or `helm upgrade` to these charts. Make sure to set `gm_control_stats_addr`'s type to `value` before you install/upgrade. Also make sure you're using the latest version of gm-control (might require building locally and importing the images into your cluster). 
<br/><br/>
