### PR TITLE
remove pod name from mongodb SVC

### DIFF
--- a/data/Chart.yaml
+++ b/data/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2
 description: A Helm chart to deploy Grey Matter Data
 name: data
-version: 2.2.1
+version: 2.2.2
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/data/Chart.yaml
+++ b/data/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2
 description: A Helm chart to deploy Grey Matter Data
 name: data
-version: 2.2.2
+version: 2.3.0
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/data/gm-data/templates/_helpers.tpl
+++ b/data/gm-data/templates/_helpers.tpl
@@ -15,7 +15,7 @@ Define the mongo host.
 {{- define "greymatter.mongo.address" -}}
 {{- $mongo := dict "servers" (list) -}}
 {{- range $i, $e := until (atoi (printf "%d" (int64 .Values.mongo.replicas))) -}} 
-{{- $noop := printf "%s%s%d.%s.%s.%s"  $.Values.mongo.name "-" . $.Values.mongo.name $.Release.Namespace "svc:27017" | append $mongo.servers | set $mongo "servers" -}}
+{{- $noop := printf "%s.%s.%s"  $.Values.mongo.name $.Release.Namespace "svc:27017" | append $mongo.servers | set $mongo "servers" -}}
 {{- end -}}
 {{- join "," $mongo.servers -}}
 {{- end -}}

--- a/docs/Ingress.md
+++ b/docs/Ingress.md
@@ -8,6 +8,9 @@
       - [With Voyager](#with-voyager)
       - [With another Ingress Controller](#with-another-ingress-controller)
     - [OpenShift](#openshift)
+  - [Automatic Ingress](#automatic-ingress)
+    - [AWS (EKS)](#aws-eks)
+    - [GCP (GKE)](#gcp-gke)
 
 >Grey Matter requires that the Edge service perform TLS termination.  Therefore, any ingress options need to be configured for TLS passthrough.
 
@@ -103,3 +106,25 @@ Whichever ingress controller you choose, it needs to allow for SSL passthrough.
 ### OpenShift
 
 In OpenShift, ingress is defined as a Route with the URL described above. No additional steps are required as the OpenShift router will automatically handle all traffic for you.
+
+## Automatic Ingress
+
+The default type of the Edge svc is ClusterIP.  This is good for when a separate ingress is going to be provisioned.  However, for a quickstart setup it may be useful to have the cloud provider automatically provision this for you.  
+
+To do so, set the `edge.ingress.type=LoadBalancer` when installing the `edge` charts, e.g.: `helm install edge edge --set=global.environment=eks --set=edge.ingress.type=LoadBalancer -f global.yaml`.  This will cause the cloud provider to setup a native load balancer to handle traffic in to your cluster.  You will be able to access your edge via the `EXTERNAL-IP` of the edge svc like shown below:
+
+### AWS (EKS)
+
+```bash
+$ kubectl get svc edge
+NAME   TYPE           CLUSTER-IP       EXTERNAL-IP                                                              PORT(S)                          AGE
+edge   LoadBalancer   10.100.208.192   a038cb433f4c140548045507a288a644-975336825.us-east-1.elb.amazonaws.com   10808:31346/TCP,8081:32018/TCP   83m
+```
+
+### GCP (GKE)
+
+```bash
+$ kubectl get svc edge
+NAME   TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)                          AGE
+edge   LoadBalancer   10.15.248.43   35.232.167.96   10808:30429/TCP,8081:32461/TCP   12m
+```

--- a/edge/Chart.yaml
+++ b/edge/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.0
 description: A Helm chart to deploy Grey Matter Edge
 name: edge
-version: 2.2.2
+version: 2.3.0
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/edge/Chart.yaml
+++ b/edge/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.0
 description: A Helm chart to deploy Grey Matter Edge
 name: edge
-version: 2.2.1
+version: 2.2.2
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/edge/templates/edge-service.yaml
+++ b/edge/templates/edge-service.yaml
@@ -14,4 +14,4 @@ spec:
   selector:
     {{ .Values.global.control.cluster_label }}: edge
   sessionAffinity: None
-  type: ClusterIP
+  type: {{ .Values.edge.ingress.type }}

--- a/edge/values.yaml
+++ b/edge/values.yaml
@@ -81,6 +81,9 @@ edge:
       mount_point: /etc/proxy/tls/sidecar/
   # If set, enables ingress TLS on the edge proxy using the secret specified in secret_name
   ingress:
+    # type is used to set how the edge k8s svc resource is created.  For depoyments using NGINX or Voyager or some other
+    # provisioned ingress, leave this as "ClusterIP".   If you want an ingress point automatically created by the cloud provider
+    # set this to "LoadBalancer"
     type: ClusterIP
     secret:
       enabled: true

--- a/edge/values.yaml
+++ b/edge/values.yaml
@@ -81,6 +81,7 @@ edge:
       mount_point: /etc/proxy/tls/sidecar/
   # If set, enables ingress TLS on the edge proxy using the secret specified in secret_name
   ingress:
+    type: ClusterIP
     secret:
       enabled: true
       secret_name: greymatter-edge-ingress

--- a/fabric/control-api/templates/control-api-service.yaml
+++ b/fabric/control-api/templates/control-api-service.yaml
@@ -6,5 +6,5 @@ spec:
   selector:
     {{ .Values.global.control.cluster_label }}: {{ .Values.controlApi.name }}
   ports:
-  - port: {{ .Values.controlApi.container_port }}
-    targetPort: {{ .Values.controlApi.container_port }}
+    - port: {{ .Values.controlApi.container_port }}
+      targetPort: {{ .Values.controlApi.container_port }}

--- a/sense/catalog/Chart.yaml
+++ b/sense/catalog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.0.3
 description: A Helm chart to deploy Grey Matter Catalog
 name: catalog
-version: 2.2.3
+version: 2.3.0
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/sense/catalog/Chart.yaml
+++ b/sense/catalog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.0.3
 description: A Helm chart to deploy Grey Matter Catalog
 name: catalog
-version: 2.2.2
+version: 2.2.3
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: Decipher Technology Studios Engineering

--- a/sense/catalog/templates/catalog-service.yaml
+++ b/sense/catalog/templates/catalog-service.yaml
@@ -6,8 +6,5 @@ spec:
   selector:
     {{ .Values.global.control.cluster_label }}: catalog
   ports:
-    - name: catalog
-      port: {{ .Values.catalog.port }}
+    - port: {{ .Values.catalog.port }}
       targetPort: {{ .Values.catalog.port }}
-  type: ClusterIP
-  sessionAffinity: None


### PR DESCRIPTION
3 changes here:
- the mongo svc change.  This allows data to resolve mongo in both GKE and EKS (tested both)
- added a template value for the edge svc type.  This allows dev to still auto provision an ingress point.  I'll update the docs accordingly if this gets merged.
    - to test this, install the edge chart with a loadbalancer: `helm install edge edge --set=global.environment=eks --set=edge.ingress.type=LoadBalancer -f global.yaml` and it'll function as the docs say they do [here](https://docs.greymatter.io/guides/installation-kubernetes#5-accessing-the-dashboard)
- minor, seemingly irrelevant modification to the catalog svc to make it match control-api.  For some reason it didn't work as it was in GKE, now it is fine. 