### PR TITLE
Fix GitHub actions linter

### DIFF
--- a/.chart-testing/fabric-sense-data.yaml
+++ b/.chart-testing/fabric-sense-data.yaml
@@ -2,4 +2,5 @@ charts:
   - fabric
   - sense
   - data
+  - spire
 target-branch: release-2.3

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -2,8 +2,7 @@ name: Lint and Test Charts
 
 on:
   push:
-    branches:
-      - '!release-*'
+
   pull_request:
     branches:
       - release-*
@@ -18,21 +17,21 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Run chart-testing (lint edge and secrets)
-        id: lint
+        id: lint-edge-secrets
         uses: helm/chart-testing-action@v1.0.0
         with:
           command: lint
           config: .chart-testing/edge-secrets.yaml
 
       - name: Run chart-testing (lint services)
-        id: lint
+        id: lint-services
         uses: helm/chart-testing-action@v1.0.0
         with:
           command: lint
           config: .chart-testing/services.yaml
 
       - name: Run chart-testing (lint fabric sense data)
-        id: lint
+        id: lint-fabric-sense-data
         uses: helm/chart-testing-action@v1.0.0
         with:
           command: lint

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -20,6 +20,7 @@ jobs:
         id: lint-edge-secrets
         uses: helm/chart-testing-action@v1.0.0
         with:
+          image: quay.io/helmpack/chart-testing:v3.1.1
           command: lint
           config: .chart-testing/edge-secrets.yaml
 
@@ -27,11 +28,13 @@ jobs:
         id: lint-services
         uses: helm/chart-testing-action@v1.0.0
         with:
+          image: quay.io/helmpack/chart-testing:v3.1.1
           command: lint
           config: .chart-testing/services.yaml
 
   lint-umbrella-charts:
     runs-on: ubuntu-latest
+    needs: lint-charts
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -43,5 +46,6 @@ jobs:
         id: lint-fabric-sense-data
         uses: helm/chart-testing-action@v1.0.0
         with:
+          image: quay.io/helmpack/chart-testing:v3.1.1
           command: lint
           config: .chart-testing/fabric-sense-data.yaml

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -7,7 +7,7 @@ on:
     branches:
       - release-*
 jobs:
-  lint-test:
+  lint-charts:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -29,6 +29,15 @@ jobs:
         with:
           command: lint
           config: .chart-testing/services.yaml
+
+  lint-umbrella-charts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
 
       - name: Run chart-testing (lint fabric sense data)
         id: lint-fabric-sense-data

--- a/charts/data/Chart.yaml
+++ b/charts/data/Chart.yaml
@@ -1,9 +1,8 @@
 apiVersion: v2
 appVersion: 1.2.0
-description: A Helm chart to deploy the Spire Agent
-name: agent
+description: A Helm chart to deploy Grey Matter Data
+name: data
 version: 2.2.2
-home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: greymatter-io
@@ -11,5 +10,11 @@ maintainers:
 keywords:
   - Grey Matter
   - service mesh
-  - spire
-  - agent
+  - data
+dependencies:
+  # todo: combine into one chart
+  - name: gm-data
+    repository: file://./gm-data
+    version: '2.2.3'
+    alias: data
+    condition: global.data.external.enabled

--- a/charts/edge/Chart.yaml
+++ b/charts/edge/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-description: A Helm chart to deploy secrets
-name: secrets
-version: 2.2.0
-home: https://greymatter.io
+appVersion: 1.0.0
+description: A Helm chart to deploy Grey Matter Edge
+name: edge
+version: 2.2.1
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: greymatter-io
@@ -10,4 +10,3 @@ maintainers:
 keywords:
   - Grey Matter
   - service mesh
-  - sense

--- a/charts/fabric/Chart.yaml
+++ b/charts/fabric/Chart.yaml
@@ -3,7 +3,6 @@ appVersion: 1.2.0
 description: A Helm chart to deploy Grey Matter Fabric
 name: fabric
 version: 2.2.1
-home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: greymatter-io

--- a/charts/sense/Chart.yaml
+++ b/charts/sense/Chart.yaml
@@ -3,7 +3,6 @@ appVersion: 1.2.0
 description: A Helm chart to deploy Grey Matter Sense
 name: sense
 version: 2.2.2
-home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: greymatter-io

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -3,7 +3,6 @@ appVersion: 1.2
 description: A Helm chart to deploy Spire
 name: spire
 version: 2.2.1
-home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: greymatter-io

--- a/data/Chart.yaml
+++ b/data/Chart.yaml
@@ -16,6 +16,6 @@ dependencies:
   # todo: combine into one chart
   - name: gm-data
     repository: file://./gm-data
-    version: '2.2.3'
+    version: '2.2.4'
     alias: data
     condition: global.data.external.enabled

--- a/data/Chart.yaml
+++ b/data/Chart.yaml
@@ -3,6 +3,7 @@ appVersion: 1.2.0
 description: A Helm chart to deploy Grey Matter Data
 name: data
 version: 2.2.2
+home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: greymatter-io

--- a/data/gm-data/Chart.yaml
+++ b/data/gm-data/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 appVersion: 1.0.0
 description: A Helm chart to deploy Grey Matter Data
-name: gm-data
-version: 2.2.3
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
-maintainers:
-  - name: greymatter-io
-    email: engineering@greyatter.io
 keywords:
-  - Grey Matter
-  - service mesh
+- Grey Matter
+- service mesh
+maintainers:
+- email: engineering@greyatter.io
+  name: greymatter-io
+name: gm-data
+version: 2.2.4

--- a/data/gm-data/Chart.yaml
+++ b/data/gm-data/Chart.yaml
@@ -3,6 +3,7 @@ appVersion: 1.0.0
 description: A Helm chart to deploy Grey Matter Data
 name: gm-data
 version: 2.2.3
+home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: greymatter-io

--- a/fabric/Chart.yaml
+++ b/fabric/Chart.yaml
@@ -15,18 +15,18 @@ keywords:
 dependencies:
   - name: control-api
     repository: file://./control-api
-    version: '2.2.3'
+    version: '2.2.4'
 
   - name: control
     repository: file://./control
-    version: '2.2.2'
+    version: '2.2.3'
 
   - name: jwt
     repository: file://./jwt
-    version: '2.2.2'
+    version: '2.2.3'
 
   - name: redis
     repository: file://./redis
-    version: '1.0.1'
+    version: '1.0.2'
     condition: global.external_redis.disabled
     alias: mesh-redis

--- a/fabric/control-api/Chart.yaml
+++ b/fabric/control-api/Chart.yaml
@@ -3,6 +3,7 @@ appVersion: 1.1.0
 description: Deploys the Grey Matter 2.0 control-api mesh-wide configuration API
 name: control-api
 version: 2.2.3
+home: https://greymatter.io
 maintainers:
   - name: greymatter-io
     email: engineering@greymatter.io

--- a/fabric/control-api/Chart.yaml
+++ b/fabric/control-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.1.0
 description: Deploys the Grey Matter 2.0 control-api mesh-wide configuration API
 name: control-api
-version: 2.2.3
+version: 2.2.4
 home: https://greymatter.io
 maintainers:
   - name: greymatter-io

--- a/fabric/control/Chart.yaml
+++ b/fabric/control/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v2
 appVersion: 1.1.0
 description: Deploys the Grey Matter 2.0 control server
 name: control
+home: https://greymatter.io
 version: 2.2.2
 maintainers:
   - name: greymatter-io

--- a/fabric/control/Chart.yaml
+++ b/fabric/control/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.1.0
 description: Deploys the Grey Matter 2.0 control server
 name: control
 home: https://greymatter.io
-version: 2.2.2
+version: 2.2.3
 maintainers:
   - name: greymatter-io
     email: engineering@greymatter.io

--- a/fabric/jwt-gov/Chart.yaml
+++ b/fabric/jwt-gov/Chart.yaml
@@ -3,6 +3,7 @@ appVersion: 1.0.0
 description: A Helm chart to deploy Grey Matter JWT Security Gov
 name: jwt-gov
 version: 2.2.2
+home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: greymatter-io

--- a/fabric/jwt-gov/Chart.yaml
+++ b/fabric/jwt-gov/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.0.0
 description: A Helm chart to deploy Grey Matter JWT Security Gov
 name: jwt-gov
-version: 2.2.2
+version: 2.2.3
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/fabric/jwt/Chart.yaml
+++ b/fabric/jwt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.0.0
 description: A Helm chart to deploy Grey Matter JWT Security
 name: jwt
-version: 2.2.2
+version: 2.2.3
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/fabric/jwt/Chart.yaml
+++ b/fabric/jwt/Chart.yaml
@@ -3,6 +3,7 @@ appVersion: 1.0.0
 description: A Helm chart to deploy Grey Matter JWT Security
 name: jwt
 version: 2.2.2
+home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: greymatter-io

--- a/fabric/redis/Chart.yaml
+++ b/fabric/redis/Chart.yaml
@@ -3,6 +3,7 @@ appVersion: 1.0.0
 description: A Helm chart to deploy a Redis server to be used by Control API and Catalog
 name: redis
 version: 1.0.1
+home: https://greymatter.io
 maintainers:
   - name: greymatter-io
     email: engineering@greymatter.io

--- a/fabric/redis/Chart.yaml
+++ b/fabric/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.0.0
 description: A Helm chart to deploy a Redis server to be used by Control API and Catalog
 name: redis
-version: 1.0.1
+version: 1.0.2
 home: https://greymatter.io
 maintainers:
   - name: greymatter-io

--- a/sense/Chart.yaml
+++ b/sense/Chart.yaml
@@ -15,12 +15,12 @@ keywords:
 dependencies:
   - name: catalog
     repository: file://./catalog
-    version: '2.2.3'
+    version: '2.2.4'
 
   - name: dashboard
     repository: file://./dashboard
-    version: '2.2.3'
+    version: '2.2.4'
 
   - name: slo
     repository: file://./slo
-    version: '2.2.3'
+    version: '2.2.4'

--- a/sense/catalog/Chart.yaml
+++ b/sense/catalog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.0.3
 description: A Helm chart to deploy Grey Matter Catalog
 name: catalog
-version: 2.2.3
+version: 2.2.4
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/sense/catalog/Chart.yaml
+++ b/sense/catalog/Chart.yaml
@@ -3,6 +3,7 @@ appVersion: 1.0.3
 description: A Helm chart to deploy Grey Matter Catalog
 name: catalog
 version: 2.2.3
+home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: greymatter-io

--- a/sense/dashboard/Chart.yaml
+++ b/sense/dashboard/Chart.yaml
@@ -3,6 +3,7 @@ appVersion: 3.4.2
 description: A Helm chart to deploy Grey Matter Dashboard
 name: dashboard
 version: 2.2.3
+home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: greymatter-io

--- a/sense/dashboard/Chart.yaml
+++ b/sense/dashboard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 3.4.2
 description: A Helm chart to deploy Grey Matter Dashboard
 name: dashboard
-version: 2.2.3
+version: 2.2.4
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/sense/slo/Chart.yaml
+++ b/sense/slo/Chart.yaml
@@ -3,6 +3,7 @@ appVersion: 1.1.5
 description: A Helm chart to deploy Grey Matter Service Level Objectives
 name: slo
 version: 2.2.3
+home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: greymatter-io

--- a/sense/slo/Chart.yaml
+++ b/sense/slo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.1.5
 description: A Helm chart to deploy Grey Matter Service Level Objectives
 name: slo
-version: 2.2.3
+version: 2.2.4
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/spire/Chart.yaml
+++ b/spire/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.2
+appVersion: 1.2.0
 description: A Helm chart to deploy Spire
 name: spire
 version: 2.2.1
@@ -16,8 +16,8 @@ keywords:
 dependencies:
   - name: agent
     repository: file://./agent
-    version: '2.2.2'
+    version: '2.2.3'
 
   - name: server
     repository: file://./server
-    version: '2.2.2'
+    version: '2.2.3'

--- a/spire/agent/Chart.yaml
+++ b/spire/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy the Spire Agent
 name: agent
-version: 2.2.2
+version: 2.2.3
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/spire/server/Chart.yaml
+++ b/spire/server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy the Spire Server
 name: server
-version: 2.2.2
+version: 2.2.3
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/spire/server/Chart.yaml
+++ b/spire/server/Chart.yaml
@@ -3,6 +3,7 @@ appVersion: 1.2.0
 description: A Helm chart to deploy the Spire Server
 name: server
 version: 2.2.2
+home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: greymatter-io


### PR DESCRIPTION
This PR gets the GitHub Actions Linter working as expected.  It still runs CircleCI for now and will continue to do so until we fully move to GitHub Actions for full CI/CD of the helm charts