### PR TITLE
increase the circle resource size to allow helm tests to complete

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,6 +296,7 @@ jobs:
 
   greymatter-test:
     machine: true
+    resource_class: xlarge
     steps:
       - checkout
       - run:


### PR DESCRIPTION
The helm test job has started to fail when deploying sense and fabric. This PR increases the circleci machine resource size from medium to xlarge.  This _should_ allow the tests to pass.  I have verified that the test still complete successfully when run locally.