### PR TITLE
add context to helm test job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -370,6 +370,8 @@ workflows:
               only: /.*/
       - greymatter-test:
           <<: *slack-fail-post-steps
+          context:
+            - nexus
           requires:
             - lint-fabric-sense
           filters:


### PR DESCRIPTION
One more fix for CircleCI.  The helm jobs were failing because I switched from environment variables to a Context and was not adding  the context to the greymatter-test job.