### PR TITLE
k3d version check < 3.1.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,7 +310,7 @@ jobs:
             sudo tar -C /usr/local -xzf go1.14.7.linux-amd64.tar.gz
 
             # get and start k3d
-            wget -q -O - https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+            wget -q -O - https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v3.1.2 bash
             k3d cluster create greymatter -a 4 -p 30000:10808@loadbalancer --wait
             export KUBECONFIG=$(k3d kubeconfig write greymatter)
 

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -74,7 +74,7 @@ jobs:
           sudo tar -C /usr/local -xzf go${go_version}.linux-amd64.tar.gz
 
           # get k3d
-          wget -q -O - https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
+          wget -q -O - https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v3.1.2 bash
 
           # get kubectl
           wget "https://storage.googleapis.com/kubernetes-release/release/v${kubectl_version}/bin/linux/amd64/kubectl"

--- a/ci/scripts/k3d.sh
+++ b/ci/scripts/k3d.sh
@@ -13,13 +13,21 @@ output=$(k3d --version)
 len=${#output}
 version=${output:13:1}
 default="3"
+broken="314"
 
 if ((version < default)); 
     then
         echo '***Please update k3d to v3.0.0 or greater***'
         exit
 fi
- 
+
+bversion=${output:13:5}
+bversion="${bversion//.}"
+if ((bversion >= broken));
+    then
+        echo '***Current known bug in k3d version v3.1.4+, please install an earlier version***'
+        exit
+fi
 
 k3d cluster create $NAME -a 4 -p 30000:10808@loadbalancer && sleep 10
 


### PR DESCRIPTION
set k3d version tag to 3.1.4 following an issue with spire & k3d 3.1.4+. Also adds to the `make k3d` script with this information

see #773 