### PR TITLE
Add the missing -e to release jwt gov charts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,10 +38,11 @@ jobs:
 
       # We need to release the Fabric Gov chart too. So we just update the Fabric chart
       # and replace the jwt with jwt-gov, then rerun the chart releaser specifically at fabric
-      - run: |
+      - name: Prepare to package Fabric Gov
+        run: |
           cp -f fabric/Chart.yaml ${{ runner.temp }}/Chart.yaml
           echo "$(awk 'NR==1,/name: jwt/{sub(/name: jwt/, "name: jwt-gov")} 1' fabric/Chart.yaml)" > fabric/Chart.yaml
-          sed -i "s|name: fabric|name: fabric-gov|" -e "s|Grey Matter Fabric|Grey Matter Fabric Gov|" -e "s|/jwt|/jwt-gov|" fabric/Chart.yaml
+          sed -i -e "s|name: fabric|name: fabric-gov|" -e "s|Grey Matter Fabric|Grey Matter Fabric Gov|" -e "s|/jwt|/jwt-gov|" fabric/Chart.yaml
 
       - name: Release Fabric Gov Chart
         uses: helm/chart-releaser-action@v1.0.0


### PR DESCRIPTION
Fixes an error releasing the fabric gov charts.  I used https://github.com/nektos/act to find my error.