### PR TITLE
Removed waiter-sa error from makefiles (#626)

### DIFF
--- a/data/Makefile
+++ b/data/Makefile
@@ -5,8 +5,7 @@ CHART_DATA := .
 include ../output.mk
 
 wsa-data:
-	$(eval WAITERSACHECK-DATA=$(shell kubectl get sa waiter-sa | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}'))
-	echo $(WAITERSACHECK-DATA)
+	$(eval WAITERSACHECK-DATA=$(shell kubectl get sa waiter-sa 2> /dev/null | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}'))
 
 .PHONY: gm-data
 gm-data: wsa-data

--- a/fabric/Makefile
+++ b/fabric/Makefile
@@ -5,7 +5,7 @@ CHART-FABRIC := .
 include ../output.mk
 
 wsa-fabric:
-	$(eval WAITERSACHECK-FABRIC=$(shell kubectl get sa waiter-sa | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}'))
+	$(eval WAITERSACHECK-FABRIC=$(shell kubectl get sa waiter-sa 2> /dev/null | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}'))
 
 .PHONY: control
 control: wsa-fabric

--- a/sense/Makefile
+++ b/sense/Makefile
@@ -5,8 +5,7 @@ CHART-SENSE := .
 include ../output.mk
 
 wsa-sense:
-	$(eval WAITERSACHECK-SENSE=$(shell kubectl get sa waiter-sa | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}'))
-	@echo $(WAITERSACHECK-SENSE)
+	$(eval WAITERSACHECK-SENSE=$(shell kubectl get sa waiter-sa 2> /dev/null | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}'))
 
 helm-validator:
 	$(eval HELM_VALIDATION=$(shell helm version --short | cut -d'+' -f1 | awk -Fv '{if ($$2 > 3.2) print "--disable-openapi-validation"}'))

--- a/spire/Makefile
+++ b/spire/Makefile
@@ -5,8 +5,7 @@ CHART-SPIRE := .
 include ../output.mk
 
 wsa-spire:
-	$(eval WAITERSACHECK-SPIRE=$(shell kubectl get sa waiter-sa | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}'))
-	echo $(WAITERSACHECK-SPIRE)
+	$(eval WAITERSACHECK-SPIRE=$(shell kubectl get sa waiter-sa 2> /dev/null | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}'))
 
 .PHONY: server
 server: wsa-spire


### PR DESCRIPTION
Issue #626 

Redirected the error stream for the `kubectl get sa waiter-sa` call to `/dev/null`. Also removed some extraneous echo statements.