### PR TITLE
point waiter images to the new greymatter.io docker repo

### DIFF
--- a/data/Chart.yaml
+++ b/data/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Grey Matter Data
 name: data
-version: 2.2.3
+version: 2.2.4
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
@@ -16,6 +16,6 @@ dependencies:
   # todo: combine into one chart
   - name: gm-data
     repository: file://./gm-data
-    version: '3.0.1'
+    version: '3.0.2'
     alias: data
     condition: global.data.external.enabled

--- a/data/gm-data/Chart.yaml
+++ b/data/gm-data/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 - email: engineering@greyatter.io
   name: greymatter-io
 name: gm-data
-version: 3.0.1
+version: 3.0.2

--- a/data/gm-data/values.yaml
+++ b/data/gm-data/values.yaml
@@ -27,7 +27,7 @@ global:
     edge_port: 10808
   # Configures the init container used to wait on various deployments to be ready
   waiter:
-    image: deciphernow/k8s-waiter:latest
+    image: docker.greymatter.io/internal/k8s-waiter:latest
     service_account:
       create: true
       name: waiter-sa

--- a/data/values.yaml
+++ b/data/values.yaml
@@ -49,7 +49,7 @@ global:
         value: '/dev/stdout'
   # Configures the init container used to wait on various deployments to be ready
   waiter:
-    image: deciphernow/k8s-waiter:latest
+    image: docker.greymatter.io/internal/k8s-waiter:latest
     service_account:
       create: true
       name: waiter-sa

--- a/docs/Service Accounts.md
+++ b/docs/Service Accounts.md
@@ -35,7 +35,7 @@ Each of the Grey Matter charts has the ability to create the necessary service a
 ```yaml
 global:
   waiter:
-    image: deciphernow/k8s-waiter:latest
+    image: docker.greymatter.io/internal/k8s-waiter:latest
     service_account:
       create: true
       name: waiter-sa

--- a/fabric/Chart.yaml
+++ b/fabric/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Grey Matter Fabric
 name: fabric
-version: 2.2.3
+version: 2.2.5
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
@@ -15,11 +15,11 @@ keywords:
 dependencies:
   - name: control-api
     repository: file://./control-api
-    version: '3.0.1'
+    version: '3.0.2'
 
   - name: control
     repository: file://./control
-    version: '2.2.4'
+    version: '2.2.5'
 
   - name: jwt
     repository: file://./jwt

--- a/fabric/control-api/Chart.yaml
+++ b/fabric/control-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.1.0
 description: Deploys the Grey Matter 2.0 control-api mesh-wide configuration API
 name: control-api
-version: 3.0.1
+version: 3.0.2
 home: https://greymatter.io
 maintainers:
   - name: greymatter-io

--- a/fabric/control-api/values.yaml
+++ b/fabric/control-api/values.yaml
@@ -30,7 +30,7 @@ global:
     path: '/run/spire/socket/agent.sock'
   # Configures the init container used to wait on various deployments to be ready
   waiter:
-    image: deciphernow/k8s-waiter:latest
+    image: docker.greymatter.io/internal/k8s-waiter:latest
     service_account:
       create: true
       name: waiter-sa

--- a/fabric/control/Chart.yaml
+++ b/fabric/control/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.1.0
 description: Deploys the Grey Matter 2.0 control server
 name: control
 home: https://greymatter.io
-version: 2.2.4
+version: 2.2.5
 maintainers:
   - name: greymatter-io
     email: engineering@greymatter.io

--- a/fabric/control/values.yaml
+++ b/fabric/control/values.yaml
@@ -22,7 +22,7 @@ global:
     additional_namespaces:
   # Configures the init container used to wait on various deployments to be ready
   waiter:
-    image: deciphernow/k8s-waiter:latest
+    image: docker.greymatter.io/internal/k8s-waiter:latest
     service_account:
       create: true
       name: waiter-sa

--- a/fabric/values.yaml
+++ b/fabric/values.yaml
@@ -33,7 +33,7 @@ global:
     path: '/run/spire/socket/agent.sock'
   # Configures the init container used to wait on various deployments to be ready
   waiter:
-    image: deciphernow/k8s-waiter:latest
+    image: docker.greymatter.io/internal/k8s-waiter:latest
     service_account:
       create: true
       name: waiter-sa

--- a/global.yaml
+++ b/global.yaml
@@ -49,7 +49,7 @@ global:
     path: '/run/spire/socket/agent.sock'
   # Configures the init container used to wait on various deployments to be ready
   waiter:
-    image: deciphernow/k8s-waiter:latest
+    image: docker.greymatter.io/internal/k8s-waiter:latest
     service_account:
       name: waiter-sa
   # Global sidecar config (supports version and envvars)

--- a/sense/Chart.yaml
+++ b/sense/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
 dependencies:
   - name: catalog
     repository: file://./catalog
-    version: '3.0.0'
+    version: '3.0.1'
 
   - name: dashboard
     repository: file://./dashboard
@@ -23,4 +23,4 @@ dependencies:
 
   - name: slo
     repository: file://./slo
-    version: '2.2.4'
+    version: '2.2.5'

--- a/sense/catalog/Chart.yaml
+++ b/sense/catalog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.0.3
 description: A Helm chart to deploy Grey Matter Catalog
 name: catalog
-version: 3.0.0
+version: 3.0.1
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/sense/catalog/values.yaml
+++ b/sense/catalog/values.yaml
@@ -29,7 +29,7 @@ global:
     path: '/run/spire/socket/agent.sock'
   # Configures the init container used to wait on various deployments to be ready
   waiter:
-    image: deciphernow/k8s-waiter:latest
+    image: docker.greymatter.io/internal/k8s-waiter:latest
     service_account:
       name: waiter-sa
   # Global sidecar config (supports version and envvars)

--- a/sense/slo/Chart.yaml
+++ b/sense/slo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.1.5
 description: A Helm chart to deploy Grey Matter Service Level Objectives
 name: slo
-version: 2.2.4
+version: 2.2.5
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/sense/slo/values.yaml
+++ b/sense/slo/values.yaml
@@ -25,7 +25,7 @@ global:
     path: '/run/spire/socket/agent.sock'
   # Configures the init container used to wait on various deployments to be ready
   waiter:
-    image: deciphernow/k8s-waiter:latest
+    image: docker.greymatter.io/internal/k8s-waiter:latest
     service_account:
       name: waiter-sa
   # Global sidecar configuration (supports global version and envvars)

--- a/sense/values.yaml
+++ b/sense/values.yaml
@@ -31,7 +31,7 @@ global:
     path: '/run/spire/socket/agent.sock'
   # Configures the init container used to wait on various deployments to be ready
   waiter:
-    image: deciphernow/k8s-waiter:latest
+    image: docker.greymatter.io/internal/k8s-waiter:latest
     service_account:
       create: true
       name: waiter-sa


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**
for ISSUE#793
1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

uses the waiter image in greymatter.io repo instead of deciphernow dockerhub

2. What **changes to custom.yaml** are required?

several of the values files changed and the parent values files along with them and the global.yaml to point to the correct image repo

3. Have you documented any additional setup steps or configurations options?

none needed.

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

make install

