### PR TITLE
Use catalog_db value for external-redis

### DIFF
--- a/sense/Chart.yaml
+++ b/sense/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
 dependencies:
   - name: catalog
     repository: file://./catalog
-    version: '3.0.2'
+    version: '3.0.3'
 
   - name: dashboard
     repository: file://./dashboard

--- a/sense/catalog/Chart.yaml
+++ b/sense/catalog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.1.0
 description: A Helm chart to deploy Grey Matter Catalog
 name: catalog
-version: 3.0.2
+version: 3.0.3
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/sense/catalog/values.yaml
+++ b/sense/catalog/values.yaml
@@ -92,7 +92,7 @@ catalog:
       value: '{{- if .Values.global.external_redis.disabled }}{{- else}}{{ .Values.global.external_redis.pass }}{{- end }}'
     redis_db:
       type: value
-      value: '{{- if .Values.global.external_redis.disabled }}1{{- else}}{{ .Values.global.external_redis.control_api_db }}{{- end }}'
+      value: '{{- if .Values.global.external_redis.disabled }}1{{- else}}{{ .Values.global.external_redis.catalog_db }}{{- end }}'
     redis_max_retries:
       type: value
       value: '{{- if .Values.global.external_redis.disabled }}50{{- else}}{{ .Values.global.external_redis.max_retries }}{{- end }}'

--- a/sense/values.yaml
+++ b/sense/values.yaml
@@ -370,7 +370,7 @@ catalog:
         value: '{{- if .Values.global.external_redis.disabled }}{{- else}}{{ .Values.global.external_redis.pass }}{{- end }}'
       redis_db:
         type: value
-        value: '{{- if .Values.global.external_redis.disabled }}1{{- else}}{{ .Values.global.external_redis.control_api_db }}{{- end }}'
+        value: '{{- if .Values.global.external_redis.disabled }}1{{- else}}{{ .Values.global.external_redis.catalog_db }}{{- end }}'
       redis_max_retries:
         type: value
         value: '{{- if .Values.global.external_redis.disabled }}50{{- else}}{{ .Values.global.external_redis.max_retries }}{{- end }}'


### PR DESCRIPTION
This fixes the reference to Catalog's database index when configured to use an external Redis provider. I had originally duplicated Catalog API's database index (`control_api_db`), which caused Catalog and Control API to share the same database.