### PR TITLE
add quotes to the password

### DIFF
--- a/ci/scripts/credentials.template
+++ b/ci/scripts/credentials.template
@@ -2,7 +2,7 @@ dockerCredentials:
   - registry: docker.greymatter.io
     email: $EMAIL
     username: $EMAIL
-    password: $PASSWORD
+    password: "$PASSWORD"
 
 data:
   data:


### PR DESCRIPTION
There may be a time when a user has a password that starts with a special character. If this is the case, the make secrets command will error with the following error:

cd secrets && make secrets
cp ../credentials.yaml .
# Ensure that the rds.enabled is true in secrets and in fabric values files
rds.enabled in secrets/values.yaml and sense/values.yaml match
helm install secrets . -f credentials.yaml -f ../global.yaml
Error: failed to parse credentials.yaml: error converting YAML to JSON: yaml: line 5: found character that cannot start any token
make[1]: *** [secrets] Error 1
make: *** [secrets] Error 2
The YAML failure is with the special character. This PR just puts quotes around the password to ensure that any password will be accepted.

I'll push a PR against release-2.2 also.