### PR TITLE
WIP: turn on admin endpoint and enable incremental

### DIFF
--- a/data/values.yaml
+++ b/data/values.yaml
@@ -32,6 +32,9 @@ global:
       proxy_dynamic:
         type: 'value'
         value: 'true'
+      delta_xds:
+        type: 'value'
+        value: 'true'
       xds_zone:
         type: 'value'
         value: '{{ .Values.global.zone }}'

--- a/edge/values.yaml
+++ b/edge/values.yaml
@@ -27,7 +27,7 @@ global:
     # Port for Grey Matter Control. Used in sidecar envvars
     port: 50000
     # The label Control uses to find pods to include in the mesh
-    cluster_label: greymatter.io/control
+    cluster_label: greymatter.io/control                                             
   # Whether or not to use spire for cert management and the trust domain
   spire:
     enabled: true
@@ -46,6 +46,9 @@ edge:
       type: value
       value: 'edge'
     proxy_dynamic:
+      type: 'value'
+      value: 'true'
+    delta_xds:
       type: 'value'
       value: 'true'
     xds_zone:

--- a/fabric/control/templates/control-service.yaml
+++ b/fabric/control/templates/control-service.yaml
@@ -16,6 +16,10 @@ spec:
     port: 50000
     protocol: TCP
     targetPort: 50000
+  - name: control-admin
+    port: {{ .Values.global.control.admin_port }}
+    protocol: TCP
+    targetPort: 51000
   selector:
     run: {{ .Values.control.name }}
   type: ClusterIP

--- a/fabric/control/templates/control.yaml
+++ b/fabric/control/templates/control.yaml
@@ -29,6 +29,9 @@ spec:
             - name: grpc
               containerPort: {{ .Values.global.control.port }}
               protocol: TCP
+            - name: admin
+              containerPort: {{ .Values.global.control.admin_port }}
+              protocol: TCP
           # livenessProbe:
           #   tcpSocket:
           #     port: grpc

--- a/fabric/control/values.yaml
+++ b/fabric/control/values.yaml
@@ -16,6 +16,8 @@ global:
   control:
     # Port for Grey Matter Control. Used in sidecar envvars
     port: 50000
+    # Port for Grey Matter Control Admin API
+    admin_port: 51000
     # The label Control uses to find pods to include in the mesh
     cluster_label: greymatter.io/control
     # Comma delimited string of namespaces for control to monitor. Also used by prometheus.
@@ -123,6 +125,12 @@ control:
     gm_control_xds_server_auth_type:
       type: "value"
       value: "noclientcert"
+    xds_stats_enabled:
+      type: "value"
+      value: "true"
+    gm_control_admin_addr:
+      type: "value"
+      value: "0.0.0.0:51000"
   resources:
 
 

--- a/fabric/values.yaml
+++ b/fabric/values.yaml
@@ -45,6 +45,9 @@ global:
       proxy_dynamic:
         type: 'value'
         value: 'true'
+      delta_xds:
+        type: 'value'
+        value: 'true'
       xds_server_ca_path:
         type: 'value'
         value: /etc/proxy/tls/sidecar/ca.crt

--- a/proxy/values.yaml
+++ b/proxy/values.yaml
@@ -21,6 +21,9 @@ sidecar:
     proxy_dynamic:
       type: 'value'
       value: 'true'
+    delta_xds:
+      type: 'value'
+      value: 'true'
     xds_cluster:
       type: 'value'
       value: '{{ .Values.name }}'

--- a/sense/values.yaml
+++ b/sense/values.yaml
@@ -42,6 +42,9 @@ global:
       proxy_dynamic:
         type: 'value'
         value: 'true'
+      delta_xds:
+        type: 'value'
+        value: 'true'
       xds_zone:
         type: 'value'
         value: '{{ .Values.global.zone }}'


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

This brings in changes needed for testing control and peering into performance. It exposes the ADMIN server for making logging changes, watching pprof, and also enables the experimental stats feature within control. 

This PR also should enable incremental xDS within our proxies as we move away from SOTW.

2. What **changes to custom.yaml** are required?

N/A

3. Have you documented any additional setup steps or configurations options?

Not yet, this is an experimental feature and should not be merged.

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

This is currently deployed in buttermilk-sky: `incremental.k8s.local`. Port-forward control: 
```
kubectl port-forward service/control 51000:51000
```
Then navigate to `localhost:51000/stats` in your browser to see what xDS is up to.
