### PR TITLE
display inline docs

### DIFF
--- a/fabric/Chart.yaml
+++ b/fabric/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
 dependencies:
   - name: control-api
     repository: file://./control-api
-    version: '3.0.4'
+    version: '3.0.5'
 
   - name: control
     repository: file://./control

--- a/fabric/control-api/Chart.yaml
+++ b/fabric/control-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.5.0
 description: Deploys the Grey Matter 2.0 control-api mesh-wide configuration API
 name: control-api
-version: 3.0.4
+version: 3.0.5
 home: https://greymatter.io
 maintainers:
   - name: greymatter-io

--- a/fabric/control-api/values.yaml
+++ b/fabric/control-api/values.yaml
@@ -333,12 +333,12 @@ services:
     port: 3000
     enableInstanceMetrics: 'true'
     capability: 'Security'
-    documentation: ''
+    documentation: '/services/jwt-security/latest/'
     owner: 'Decipher'
     version: '1.2.0'
     ownerURL: "https://greymatter.io"
     apiEndpoint: 'https://{{- $.Values.global.domain }}/services/jwt-security/latest/'
-    apiSpecEndpoint: ''
+    apiSpecEndpoint: '/services/jwt-security/latest/'
     businessImpact: low
     description: The Grey Matter JWT security service is a JWT Token generation and retrieval service.
     # External links configures the "Service Tools" dropdown in service view
@@ -362,12 +362,12 @@ services:
     port: 5555
     enableInstanceMetrics: 'true'
     capability: 'Mesh'
-    documentation:
+    documentation: '/services/control-api/latest/'
     owner: 'Decipher'
     version: '1.5.0'
     ownerURL: "https://greymatter.io"
     apiEndpoint: 'https://{{- $.Values.global.domain }}/services/control-api/latest/'
-    apiSpecEndpoint: ''
+    apiSpecEndpoint: '/services/control-api/latest/'
     businessImpact: low
     description: The purpose of the Grey Matter Control API is to update the configuration of every Grey Matter Proxy in the mesh.
     # External links configures the "Service Tools" dropdown in service view
@@ -433,7 +433,7 @@ services:
     port: 1337
     enableInstanceMetrics: 'true'
     capability: 'Sense'
-    documentation:
+    documentation: '/services/slo/latest/'
     owner: 'Decipher'
     version: '1.2.0'
     ownerURL: "https://greymatter.io"

--- a/fabric/values.yaml
+++ b/fabric/values.yaml
@@ -386,12 +386,12 @@ services:
     port: 3000
     enableInstanceMetrics: 'true'
     capability: 'Security'
-    documentation: ''
+    documentation: '/services/jwt-security/latest/'
     owner: 'Decipher'
     version: '1.2.0'
     ownerURL: "https://greymatter.io"
     apiEndpoint: 'https://{{- $.Values.global.domain }}/services/jwt-security/latest/'
-    apiSpecEndpoint: ''
+    apiSpecEndpoint: '/services/jwt-security/latest/'
     businessImpact: low
     description: The Grey Matter JWT security service is a JWT Token generation and retrieval service.
     # External links configures the "Service Tools" dropdown in service view
@@ -415,12 +415,12 @@ services:
     port: 5555
     enableInstanceMetrics: 'true'
     capability: 'Mesh'
-    documentation:
+    documentation: '/services/control-api/latest/'
     owner: 'Decipher'
     version: '1.5.0'
     ownerURL: "https://greymatter.io"
     apiEndpoint: 'https://{{- $.Values.global.domain }}/services/control-api/latest/'
-    apiSpecEndpoint: ''
+    apiSpecEndpoint: '/services/control-api/latest/'
     businessImpact: low
     description: The purpose of the Grey Matter Control API is to update the configuration of every Grey Matter Proxy in the mesh.
     # External links configures the "Service Tools" dropdown in service view
@@ -486,7 +486,7 @@ services:
     port: 1337
     enableInstanceMetrics: 'true'
     capability: 'Sense'
-    documentation:
+    documentation: '/services/slo/latest/'
     owner: 'Decipher'
     version: '1.2.0'
     ownerURL: "https://greymatter.io"

--- a/sense/Chart.yaml
+++ b/sense/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
 dependencies:
   - name: catalog
     repository: file://./catalog
-    version: '3.0.3'
+    version: '3.0.4'
 
   - name: dashboard
     repository: file://./dashboard

--- a/sense/catalog/Chart.yaml
+++ b/sense/catalog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.1.0
 description: A Helm chart to deploy Grey Matter Catalog
 name: catalog
-version: 3.0.3
+version: 3.0.4
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/sense/catalog/values.yaml
+++ b/sense/catalog/values.yaml
@@ -302,12 +302,12 @@ services:
     port: 3000
     enableInstanceMetrics: 'true'
     capability: 'Security'
-    documentation: ''
+    documentation: '/services/jwt-security/latest/'
     owner: 'Decipher'
     version: '1.2.0'
     ownerURL: "https://greymatter.io"
     apiEndpoint: 'https://{{- $.Values.global.domain }}/services/jwt-security/latest/'
-    apiSpecEndpoint: ''
+    apiSpecEndpoint: '/services/jwt-security/latest/'
     businessImpact: low
     description: The Grey Matter JWT security service is a JWT Token generation and retrieval service.
     # External links configures the "Service Tools" dropdown in service view
@@ -331,12 +331,12 @@ services:
     port: 5555
     enableInstanceMetrics: 'true'
     capability: 'Mesh'
-    documentation:
+    documentation: '/services/control-api/latest/'
     owner: 'Decipher'
     version: '1.5.0'
     ownerURL: "https://greymatter.io"
     apiEndpoint: 'https://{{- $.Values.global.domain }}/services/control-api/latest/'
-    apiSpecEndpoint: ''
+    apiSpecEndpoint: '/services/control-api/latest/'
     businessImpact: low
     description: The purpose of the Grey Matter Control API is to update the configuration of every Grey Matter Proxy in the mesh.
     # External links configures the "Service Tools" dropdown in service view
@@ -402,7 +402,7 @@ services:
     port: 1337
     enableInstanceMetrics: 'true'
     capability: 'Sense'
-    documentation:
+    documentation: '/services/slo/latest/'
     owner: 'Decipher'
     version: '1.2.0'
     ownerURL: "https://greymatter.io"

--- a/sense/values.yaml
+++ b/sense/values.yaml
@@ -266,7 +266,7 @@ dashboard:
       # Enables inline API documentation in service and instance views
       enable_inline_docs:
         type: "value"
-        value: "false"
+        value: "true"
 
     # Sidecar configuration overrides for dashboard
     sidecar:
@@ -536,12 +536,12 @@ services:
     port: 3000
     enableInstanceMetrics: 'true'
     capability: 'Security'
-    documentation: ''
+    documentation: '/services/jwt-security/latest/'
     owner: 'Decipher'
     version: '1.2.0'
     ownerURL: "https://greymatter.io"
     apiEndpoint: 'https://{{- $.Values.global.domain }}/services/jwt-security/latest/'
-    apiSpecEndpoint: ''
+    apiSpecEndpoint: '/services/jwt-security/latest/'
     businessImpact: low
     description: The Grey Matter JWT security service is a JWT Token generation and retrieval service.
     # External links configures the "Service Tools" dropdown in service view
@@ -565,12 +565,12 @@ services:
     port: 5555
     enableInstanceMetrics: 'true'
     capability: 'Mesh'
-    documentation:
+    documentation: '/services/control-api/latest/'
     owner: 'Decipher'
     version: '1.5.0'
     ownerURL: "https://greymatter.io"
     apiEndpoint: 'https://{{- $.Values.global.domain }}/services/control-api/latest/'
-    apiSpecEndpoint: ''
+    apiSpecEndpoint: '/services/control-api/latest/'
     businessImpact: low
     description: The purpose of the Grey Matter Control API is to update the configuration of every Grey Matter Proxy in the mesh.
     # External links configures the "Service Tools" dropdown in service view
@@ -636,7 +636,7 @@ services:
     port: 1337
     enableInstanceMetrics: 'true'
     capability: 'Sense'
-    documentation:
+    documentation: '/services/slo/latest/'
     owner: 'Decipher'
     version: '1.2.0'
     ownerURL: "https://greymatter.io"


### PR DESCRIPTION
resolves https://github.com/greymatter-io/helm-charts/issues/811

- Sets enable_inline_docs true
- Updates services that did not have apiSpecEndpoint/documentation set


to test:

- `make k3d install`
- Check the dashboard and see that all core services besides edge and dashboard are rendering inline docs