### PR TITLE
use relative paths for apiEndpoints

### DIFF
--- a/fabric/Chart.yaml
+++ b/fabric/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
 dependencies:
   - name: control-api
     repository: file://./control-api
-    version: '3.0.5'
+    version: '3.0.6'
 
   - name: control
     repository: file://./control

--- a/fabric/Chart.yaml
+++ b/fabric/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.3.0
 description: A Helm chart to deploy Grey Matter Fabric
 name: fabric
-version: 3.0.1
+version: 3.0.2
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
@@ -15,7 +15,7 @@ keywords:
 dependencies:
   - name: control-api
     repository: file://./control-api
-    version: '3.0.6'
+    version: '3.0.7'
 
   - name: control
     repository: file://./control

--- a/fabric/control-api/Chart.yaml
+++ b/fabric/control-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.5.0
 description: Deploys the Grey Matter 2.0 control-api mesh-wide configuration API
 name: control-api
-version: 3.0.6
+version: 3.0.7
 home: https://greymatter.io
 maintainers:
   - name: greymatter-io

--- a/fabric/control-api/Chart.yaml
+++ b/fabric/control-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.5.0
 description: Deploys the Grey Matter 2.0 control-api mesh-wide configuration API
 name: control-api
-version: 3.0.5
+version: 3.0.6
 home: https://greymatter.io
 maintainers:
   - name: greymatter-io

--- a/fabric/control-api/values.yaml
+++ b/fabric/control-api/values.yaml
@@ -63,7 +63,7 @@ controlApi:
   # Number of replicas for the deployment
   replicas: 1
   version: 1.5.0
-  image: 'docker.greymatter.io/development/gm-control-api:{{ .Values.controlApi.version }}'
+  image: 'docker.greymatter.io/development/gm-control-api:1.6.0-dev'
   # When to pull images, used in the deployment
   image_pull_policy: IfNotPresent
   # Port exposed by the control-api container
@@ -142,7 +142,7 @@ controlApi:
     # The following envvars enable the experimental control-api explorer UI
     gm_control_api_experiments:
       type: value
-      value: 'false'
+      value: 'true'
     gm_control_api_base_url:
       type: value
       value: '/services/control-api/latest/v1.0/'
@@ -234,7 +234,7 @@ services:
     minInstances: 1
     maxInstances: 1
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}/services/catalog/latest/'
+    apiEndpoint: 'services/catalog/latest/'
     apiSpecEndpoint: '/services/catalog/latest/'
     businessImpact: low
     description: The Grey Matter Catalog service interfaces with the Fabric mesh xDS interface to provide high level summaries and more easily consumable views of the current state of the mesh. It powers the Grey Matter application and any other applications that need to understand what is present in the mesh.
@@ -267,7 +267,7 @@ services:
     owner: 'Decipher'
     version: 4.0.0
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}'
+    apiEndpoint: ''
     apiSpecEndpoint: ''
     businessImpact: low
     description: The Grey Matter application is a user dashboard that paints a high-level picture of the service mesh.
@@ -308,7 +308,7 @@ services:
     owner: 'Decipher'
     version: 1.1.3
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}/services/data/latest/'
+    apiEndpoint: 'services/data/latest/'
     apiSpecEndpoint: '/latest/static/'
     businessImpact: low
     description: Grey Matter Data is an API that enables secure and flexible access control for your microservices.
@@ -337,7 +337,7 @@ services:
     owner: 'Decipher'
     version: '1.2.0'
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}/services/jwt-security/latest/'
+    apiEndpoint: 'services/jwt-security/latest/'
     apiSpecEndpoint: '/services/jwt-security/latest/'
     businessImpact: low
     description: The Grey Matter JWT security service is a JWT Token generation and retrieval service.
@@ -366,7 +366,7 @@ services:
     owner: 'Decipher'
     version: '1.5.0'
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}/services/control-api/latest/'
+    apiEndpoint: 'services/control-api/latest/'
     apiSpecEndpoint: '/services/control-api/latest/'
     businessImpact: low
     description: The purpose of the Grey Matter Control API is to update the configuration of every Grey Matter Proxy in the mesh.
@@ -399,7 +399,7 @@ services:
     owner: 'Decipher'
     version: '1.5.1'
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}'
+    apiEndpoint: ''
     apiSpecEndpoint: ''
     businessImpact: low
     description: Grey Matter Edge handles north/south traffic flowing through the mesh.
@@ -437,7 +437,7 @@ services:
     owner: 'Decipher'
     version: '1.2.0'
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}/services/slo/latest/'
+    apiEndpoint: 'services/slo/latest/'
     apiSpecEndpoint: '/services/slo/latest/'
     businessImpact: low
     description: Grey Matter Service Level Objectives (SLOs) allows users to manage objectives towards service-level agreements.

--- a/fabric/control-api/values.yaml
+++ b/fabric/control-api/values.yaml
@@ -63,7 +63,7 @@ controlApi:
   # Number of replicas for the deployment
   replicas: 1
   version: 1.5.0
-  image: 'docker.greymatter.io/development/gm-control-api:1.6.0-dev'
+  image: 'docker.greymatter.io/development/gm-control-api:{{ $.Values.controlApi.version }}'
   # When to pull images, used in the deployment
   image_pull_policy: IfNotPresent
   # Port exposed by the control-api container
@@ -142,7 +142,7 @@ controlApi:
     # The following envvars enable the experimental control-api explorer UI
     gm_control_api_experiments:
       type: value
-      value: 'true'
+      value: 'false'
     gm_control_api_base_url:
       type: value
       value: '/services/control-api/latest/v1.0/'

--- a/fabric/values.yaml
+++ b/fabric/values.yaml
@@ -165,7 +165,7 @@ control-api:
     replicas: 1
     # Gm Control API version
     version: 1.5.0
-    image: 'docker.greymatter.io/development/gm-control-api:1.6.0-dev'
+    image: 'docker.greymatter.io/development/gm-control-api:{{ $.Values.controlApi.version }}'
     # When to pull images, used in the deployment
     image_pull_policy: IfNotPresent
     # Port exposed by the control-api container
@@ -244,10 +244,11 @@ control-api:
       # The following envvars enable the experimental control-api explorer UI
       gm_control_api_experiments:
         type: value
-        value: 'true'
+        value: 'false'
+      # staying at the default, just makes it easier to change when desired
       gm_control_api_disable_version_check:
         type: value
-        value: 'true'
+        value: 'false'
       gm_control_api_base_url:
         type: value
         value: '/services/control-api/latest/v1.0/'

--- a/fabric/values.yaml
+++ b/fabric/values.yaml
@@ -165,7 +165,7 @@ control-api:
     replicas: 1
     # Gm Control API version
     version: 1.5.0
-    image: 'docker.greymatter.io/development/gm-control-api:{{ $.Values.controlApi.version }}'
+    image: 'docker.greymatter.io/development/gm-control-api:1.6.0-dev'
     # When to pull images, used in the deployment
     image_pull_policy: IfNotPresent
     # Port exposed by the control-api container
@@ -244,7 +244,10 @@ control-api:
       # The following envvars enable the experimental control-api explorer UI
       gm_control_api_experiments:
         type: value
-        value: 'false'
+        value: 'true'
+      gm_control_api_disable_version_check:
+        type: value
+        value: 'true'
       gm_control_api_base_url:
         type: value
         value: '/services/control-api/latest/v1.0/'
@@ -287,7 +290,7 @@ services:
     minInstances: 1
     maxInstances: 1
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}/services/catalog/latest/'
+    apiEndpoint: 'services/catalog/latest/'
     apiSpecEndpoint: '/services/catalog/latest/'
     businessImpact: low
     description: The Grey Matter Catalog service interfaces with the Fabric mesh xDS interface to provide high level summaries and more easily consumable views of the current state of the mesh. It powers the Grey Matter application and any other applications that need to understand what is present in the mesh.
@@ -320,7 +323,7 @@ services:
     owner: 'Decipher'
     version: 4.0.0
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}'
+    apiEndpoint: ''
     apiSpecEndpoint: ''
     businessImpact: low
     description: The Grey Matter application is a user dashboard that paints a high-level picture of the service mesh.
@@ -361,7 +364,7 @@ services:
     owner: 'Decipher'
     version: 1.1.3
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}/services/data/latest/'
+    apiEndpoint: 'services/data/latest/'
     apiSpecEndpoint: '/latest/static/'
     businessImpact: low
     description: Grey Matter Data is an API that enables secure and flexible access control for your microservices.
@@ -390,7 +393,7 @@ services:
     owner: 'Decipher'
     version: '1.2.0'
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}/services/jwt-security/latest/'
+    apiEndpoint: 'services/jwt-security/latest/'
     apiSpecEndpoint: '/services/jwt-security/latest/'
     businessImpact: low
     description: The Grey Matter JWT security service is a JWT Token generation and retrieval service.
@@ -419,7 +422,7 @@ services:
     owner: 'Decipher'
     version: '1.5.0'
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}/services/control-api/latest/'
+    apiEndpoint: 'services/control-api/latest/'
     apiSpecEndpoint: '/services/control-api/latest/'
     businessImpact: low
     description: The purpose of the Grey Matter Control API is to update the configuration of every Grey Matter Proxy in the mesh.
@@ -452,7 +455,7 @@ services:
     owner: 'Decipher'
     version: '1.5.1'
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}'
+    apiEndpoint: ''
     apiSpecEndpoint: ''
     businessImpact: low
     description: Grey Matter Edge handles north/south traffic flowing through the mesh.
@@ -490,7 +493,7 @@ services:
     owner: 'Decipher'
     version: '1.2.0'
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}/services/slo/latest/'
+    apiEndpoint: 'services/slo/latest/'
     apiSpecEndpoint: '/services/slo/latest/'
     businessImpact: low
     description: Grey Matter Service Level Objectives (SLOs) allows users to manage objectives towards service-level agreements.

--- a/sense/Chart.yaml
+++ b/sense/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.3.0
 description: A Helm chart to deploy Grey Matter Sense
 name: sense
-version: 3.0.1
+version: 3.0.2
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
@@ -15,7 +15,7 @@ keywords:
 dependencies:
   - name: catalog
     repository: file://./catalog
-    version: '3.0.5'
+    version: '3.0.6'
 
   - name: dashboard
     repository: file://./dashboard

--- a/sense/Chart.yaml
+++ b/sense/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
 dependencies:
   - name: catalog
     repository: file://./catalog
-    version: '3.0.4'
+    version: '3.0.5'
 
   - name: dashboard
     repository: file://./dashboard

--- a/sense/catalog/Chart.yaml
+++ b/sense/catalog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.1.0
 description: A Helm chart to deploy Grey Matter Catalog
 name: catalog
-version: 3.0.4
+version: 3.0.5
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/sense/catalog/Chart.yaml
+++ b/sense/catalog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.1.0
 description: A Helm chart to deploy Grey Matter Catalog
 name: catalog
-version: 3.0.5
+version: 3.0.6
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/sense/catalog/values.yaml
+++ b/sense/catalog/values.yaml
@@ -203,7 +203,7 @@ services:
     minInstances: 1
     maxInstances: 1
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}/services/catalog/latest/'
+    apiEndpoint: 'services/catalog/latest/'
     apiSpecEndpoint: '/services/catalog/latest/'
     businessImpact: low
     description: The Grey Matter Catalog service interfaces with the Fabric mesh xDS interface to provide high level summaries and more easily consumable views of the current state of the mesh. It powers the Grey Matter application and any other applications that need to understand what is present in the mesh.
@@ -236,7 +236,7 @@ services:
     owner: 'Decipher'
     version: 4.0.0
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}'
+    apiEndpoint: ''
     apiSpecEndpoint: ''
     businessImpact: low
     description: The Grey Matter application is a user dashboard that paints a high-level picture of the service mesh.
@@ -277,7 +277,7 @@ services:
     owner: 'Decipher'
     version: 1.1.3
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}/services/data/latest/'
+    apiEndpoint: 'services/data/latest/'
     apiSpecEndpoint: '/latest/static/'
     businessImpact: low
     description: Grey Matter Data is an API that enables secure and flexible access control for your microservices.
@@ -306,7 +306,7 @@ services:
     owner: 'Decipher'
     version: '1.2.0'
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}/services/jwt-security/latest/'
+    apiEndpoint: 'services/jwt-security/latest/'
     apiSpecEndpoint: '/services/jwt-security/latest/'
     businessImpact: low
     description: The Grey Matter JWT security service is a JWT Token generation and retrieval service.
@@ -335,7 +335,7 @@ services:
     owner: 'Decipher'
     version: '1.5.0'
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}/services/control-api/latest/'
+    apiEndpoint: 'services/control-api/latest/'
     apiSpecEndpoint: '/services/control-api/latest/'
     businessImpact: low
     description: The purpose of the Grey Matter Control API is to update the configuration of every Grey Matter Proxy in the mesh.
@@ -368,7 +368,7 @@ services:
     owner: 'Decipher'
     version: '1.5.1'
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}'
+    apiEndpoint: ''
     apiSpecEndpoint: ''
     businessImpact: low
     description: Grey Matter Edge handles north/south traffic flowing through the mesh.
@@ -406,7 +406,7 @@ services:
     owner: 'Decipher'
     version: '1.2.0'
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}/services/slo/latest/'
+    apiEndpoint: 'services/slo/latest/'
     apiSpecEndpoint: '/services/slo/latest/'
     businessImpact: low
     description: Grey Matter Service Level Objectives (SLOs) allows users to manage objectives towards service-level agreements.

--- a/sense/values.yaml
+++ b/sense/values.yaml
@@ -437,7 +437,7 @@ services:
     minInstances: 1
     maxInstances: 1
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}/services/catalog/latest/'
+    apiEndpoint: 'services/catalog/latest/'
     apiSpecEndpoint: '/services/catalog/latest/'
     businessImpact: low
     description: The Grey Matter Catalog service interfaces with the Fabric mesh xDS interface to provide high level summaries and more easily consumable views of the current state of the mesh. It powers the Grey Matter application and any other applications that need to understand what is present in the mesh.
@@ -470,7 +470,7 @@ services:
     owner: 'Decipher'
     version: 4.0.0
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}'
+    apiEndpoint: ''
     apiSpecEndpoint: ''
     businessImpact: low
     description: The Grey Matter application is a user dashboard that paints a high-level picture of the service mesh.
@@ -511,7 +511,7 @@ services:
     owner: 'Decipher'
     version: 1.1.3
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}/services/data/latest/'
+    apiEndpoint: 'services/data/latest/'
     apiSpecEndpoint: '/latest/static/'
     businessImpact: low
     description: Grey Matter Data is an API that enables secure and flexible access control for your microservices.
@@ -540,7 +540,7 @@ services:
     owner: 'Decipher'
     version: '1.2.0'
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}/services/jwt-security/latest/'
+    apiEndpoint: 'services/jwt-security/latest/'
     apiSpecEndpoint: '/services/jwt-security/latest/'
     businessImpact: low
     description: The Grey Matter JWT security service is a JWT Token generation and retrieval service.
@@ -569,7 +569,7 @@ services:
     owner: 'Decipher'
     version: '1.5.0'
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}/services/control-api/latest/'
+    apiEndpoint: 'services/control-api/latest/'
     apiSpecEndpoint: '/services/control-api/latest/'
     businessImpact: low
     description: The purpose of the Grey Matter Control API is to update the configuration of every Grey Matter Proxy in the mesh.
@@ -602,7 +602,7 @@ services:
     owner: 'Decipher'
     version: '1.5.1'
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}'
+    apiEndpoint: ''
     apiSpecEndpoint: ''
     businessImpact: low
     description: Grey Matter Edge handles north/south traffic flowing through the mesh.
@@ -640,7 +640,7 @@ services:
     owner: 'Decipher'
     version: '1.2.0'
     ownerURL: "https://greymatter.io"
-    apiEndpoint: 'https://{{- $.Values.global.domain }}/services/slo/latest/'
+    apiEndpoint: 'services/slo/latest/'
     apiSpecEndpoint: '/services/slo/latest/'
     businessImpact: low
     description: Grey Matter Service Level Objectives (SLOs) allows users to manage objectives towards service-level agreements.


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. the apiEndpoints for each service card has "localhost" with the default charts.  this breaks the clickthrough functionality when deploying remotely.  This can just be changed to relative paths so it works in all cases.  

<br/><br/>

2. No changes needed

<br/><br/>

3. Have you documented any additional setup steps or configurations options?

no

<br/><br/>

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

![PROOOF](https://user-images.githubusercontent.com/2422189/100783559-f0753680-33db-11eb-9053-12be78d19cf3.png)

<br/><br/>
