### PR TITLE
Updated to use the 1.3 release candidate images

### DIFF
--- a/data/Chart.yaml
+++ b/data/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Grey Matter Data
 name: data
-version: 3.0.0
+version: 3.0.1
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
@@ -16,6 +16,6 @@ dependencies:
   # todo: combine into one chart
   - name: gm-data
     repository: file://./gm-data
-    version: '3.0.3'
+    version: '3.0.4'
     alias: data
     condition: global.data.external.enabled

--- a/data/gm-data/Chart.yaml
+++ b/data/gm-data/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 - email: engineering@greyatter.io
   name: greymatter-io
 name: gm-data
-version: 3.0.3
+version: 3.0.4

--- a/data/gm-data/values.yaml
+++ b/data/gm-data/values.yaml
@@ -44,7 +44,7 @@ data:
     enabled: true
     secret_name: data-secrets
 
-  image: docker.greymatter.io/development/gm-data:{{ $.Values.data.version }}
+  image: docker.greymatter.io/release/gm-data:{{ $.Values.data.version }}
   image_pull_secret: '{{ .Values.global.image_pull_secret }}'
   image_pull_policy: IfNotPresent
 
@@ -279,7 +279,7 @@ sidecar:
       ca: ca.crt
       key: server.key
       cert: server.crt
-  image: 'docker.greymatter.io/development/gm-proxy:{{ tpl $.Values.sidecar.version $ }}'
+  image: 'docker.greymatter.io/release/gm-proxy:{{ tpl $.Values.sidecar.version $ }}'
   image_pull_policy: IfNotPresent
   resources:
     limits:

--- a/data/values.yaml
+++ b/data/values.yaml
@@ -78,7 +78,7 @@ data:
     name: data
     version: 1.1.3
     replicas: 1
-    image: 'docker.greymatter.io/development/gm-data:{{ .Values.data.version }}'
+    image: 'docker.greymatter.io/release/gm-data:{{ .Values.data.version }}'
     # image_pull_secret: '{{ .Values.global.image_pull_secret }}'
     image_pull_policy: IfNotPresent
 

--- a/docs/Upgrading Sidecar Metrics to mTLS.md
+++ b/docs/Upgrading Sidecar Metrics to mTLS.md
@@ -768,7 +768,7 @@ spec:
           value: "50000"
         - name: XDS_ZONE
           value: zone-default-zone
-        image: docker.greymatter.io/development/gm-proxy:1.4.5
+        image: docker.greymatter.io/release/gm-proxy:1.5.1
         imagePullPolicy: IfNotPresent
         name: sidecar
         ports:

--- a/edge/Chart.yaml
+++ b/edge/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.1
 description: A Helm chart to deploy Grey Matter Edge
 name: edge
-version: 3.0.1
+version: 3.0.2
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: greymatter-io

--- a/edge/values.yaml
+++ b/edge/values.yaml
@@ -35,7 +35,7 @@ global:
     path: '/run/spire/socket/agent.sock'
 edge:
   version: '1.5.1'
-  image: 'docker.greymatter.io/development/gm-proxy:{{ tpl $.Values.edge.version $ }}'
+  image: 'docker.greymatter.io/release/gm-proxy:{{ tpl $.Values.edge.version $ }}'
   image_pull_policy: IfNotPresent
   # Port where the edge proxy will listen
   port: 10808

--- a/fabric/Chart.yaml
+++ b/fabric/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.3.0
 description: A Helm chart to deploy Grey Matter Fabric
 name: fabric
-version: 3.0.0
+version: 3.0.1
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
@@ -15,15 +15,15 @@ keywords:
 dependencies:
   - name: control-api
     repository: file://./control-api
-    version: '3.0.5'
+    version: '3.0.6'
 
   - name: control
     repository: file://./control
-    version: '3.0.0'
+    version: '3.0.1'
 
   - name: jwt
     repository: file://./jwt
-    version: '3.0.0'
+    version: '3.0.1'
 
   - name: redis
     repository: file://./redis

--- a/fabric/control-api/Chart.yaml
+++ b/fabric/control-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.5.0
 description: Deploys the Grey Matter 2.0 control-api mesh-wide configuration API
 name: control-api
-version: 3.0.5
+version: 3.0.6
 home: https://greymatter.io
 maintainers:
   - name: greymatter-io

--- a/fabric/control-api/values.yaml
+++ b/fabric/control-api/values.yaml
@@ -62,8 +62,8 @@ controlApi:
   display_name: control-api
   # Number of replicas for the deployment
   replicas: 1
-  version: 1.5.0
-  image: 'docker.greymatter.io/development/gm-control-api:{{ .Values.controlApi.version }}'
+  version: 1.5.2
+  image: 'docker.greymatter.io/release/gm-control-api:{{ .Values.controlApi.version }}'
   # When to pull images, used in the deployment
   image_pull_policy: IfNotPresent
   # Port exposed by the control-api container
@@ -153,7 +153,7 @@ controlApi:
 # Sidecar configuration for Control Api
 sidecar:
   version: '{{- $.Values.global.sidecar.version | default "latest" }}'
-  image: 'docker.greymatter.io/development/gm-proxy:{{ tpl $.Values.sidecar.version $ }}'
+  image: 'docker.greymatter.io/release/gm-proxy:{{ tpl $.Values.sidecar.version $ }}'
   # Port where the proxy will listen
   port: 10808
   # Port where the proxy will expose metrics
@@ -179,7 +179,8 @@ sidecar:
 
 
 bootstrap:
-  image: 'docker.greymatter.io/development/greymatter:latest'
+  version: 2.0.0
+  image: 'docker.greymatter.io/release/greymatter:{{ tpl $.Values.bootstrap.version $ }}'
   image_pull_policy: IfNotPresent
   secret:
     enabled: true

--- a/fabric/control/Chart.yaml
+++ b/fabric/control/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.5.0
 description: Deploys the Grey Matter 2.0 control server
 name: control
 home: https://greymatter.io
-version: 3.0.0
+version: 3.0.1
 maintainers:
   - name: greymatter-io
     email: engineering@greymatter.io

--- a/fabric/control/values.yaml
+++ b/fabric/control/values.yaml
@@ -38,8 +38,8 @@ control:
   # Number of replicas for the deployment
   replicas: 1
   # Version of control
-  version: 1.5.0
-  image: 'docker.greymatter.io/development/gm-control:{{ $.Values.control.version }}'
+  version: 1.5.1
+  image: 'docker.greymatter.io/release/gm-control:{{ $.Values.control.version }}'
   # When to pull images, used in the deployment
   image_pull_policy: IfNotPresent
   # Secret used to talk to control-api

--- a/fabric/jwt-gov/Chart.yaml
+++ b/fabric/jwt-gov/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Grey Matter JWT Security Gov
 name: jwt-gov
-version: 3.0.0
+version: 3.0.1
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/fabric/jwt-gov/values.yaml
+++ b/fabric/jwt-gov/values.yaml
@@ -32,7 +32,7 @@ jwt:
   version: '1.2.0'
   # If true, uses aac for auth control
   use_aac: false
-  image: 'docker-government.production.deciphernow.com/deciphernow/gm-jwt-security-gov:{{ tpl $.Values.jwt.version $ }}'
+  image: 'docker.greymatter.io/government/gm-jwt-security-gov:{{ tpl $.Values.jwt.version $ }}'
   command: ['/bin/sh']
   args:
     [
@@ -219,7 +219,7 @@ sidecar:
       ca: ca.crt
       key: server.key
       cert: server.crt
-  image: 'docker.greymatter.io/development/gm-proxy:{{ tpl $.Values.sidecar.version $ }}'
+  image: 'docker.greymatter.io/release/gm-proxy:{{ tpl $.Values.sidecar.version $ }}'
   image_pull_policy: IfNotPresent
   resources:
     limits:

--- a/fabric/jwt/Chart.yaml
+++ b/fabric/jwt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Grey Matter JWT Security
 name: jwt
-version: 3.0.0
+version: 3.0.1
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/fabric/jwt/values.yaml
+++ b/fabric/jwt/values.yaml
@@ -32,7 +32,7 @@ jwt:
   # Name used for the deployment and service resources
   name: jwt-security
   version: '1.2.0'
-  image: 'docker.greymatter.io/development/gm-jwt-security:{{ tpl $.Values.jwt.version $ }}'
+  image: 'docker.greymatter.io/release/gm-jwt-security:{{ tpl $.Values.jwt.version $ }}'
   command: ['/bin/sh']
   args:
     [
@@ -223,7 +223,7 @@ sidecar:
       ca: ca.crt
       key: server.key
       cert: server.crt
-  image: 'docker.greymatter.io/development/gm-proxy:{{ tpl $.Values.sidecar.version $ }}'
+  image: 'docker.greymatter.io/release/gm-proxy:{{ tpl $.Values.sidecar.version $ }}'
   image_pull_policy: IfNotPresent
   resources:
     limits:

--- a/fabric/values.yaml
+++ b/fabric/values.yaml
@@ -73,8 +73,8 @@ control:
     # Number of replicas for the deployment
     replicas: 1
     # Version of control
-    version: 1.5.1-dev
-    image: 'docker.greymatter.io/development/gm-control:{{ $.Values.control.version }}'
+    version: 1.5.1
+    image: 'docker.greymatter.io/release/gm-control:{{ $.Values.control.version }}'
     # When to pull images, used in the deployment
     image_pull_policy: IfNotPresent
     # Secret used to talk to control-api
@@ -164,8 +164,8 @@ control-api:
     # Number of replicas for the deployment
     replicas: 1
     # Gm Control API version
-    version: 1.5.0
-    image: 'docker.greymatter.io/development/gm-control-api:{{ $.Values.controlApi.version }}'
+    version: 1.5.2
+    image: 'docker.greymatter.io/release/gm-control-api:{{ $.Values.controlApi.version }}'
     # When to pull images, used in the deployment
     image_pull_policy: IfNotPresent
     # Port exposed by the control-api container
@@ -526,7 +526,7 @@ jwt:
     # Location to mount the information specified in users_cg_name in the container
     users_mount_point: /gm-jwt-security/etc
     version: 1.2.0
-    image: 'docker.greymatter.io/development/gm-jwt-security:{{ .Values.jwt.version }}'
+    image: 'docker.greymatter.io/release/gm-jwt-security:{{ .Values.jwt.version }}'
     port: 3000
     envvars:
       private_key:

--- a/proxy/Chart.yaml
+++ b/proxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.1
 description: A Helm chart to deploy a Grey Matter Proxy
 name: proxy
-version: 3.0.0
+version: 3.0.1
 maintainers:
   - name: Decipher Technology Studios Engineering
     email: engineering@deciphernow.com

--- a/proxy/values.yaml
+++ b/proxy/values.yaml
@@ -6,7 +6,7 @@ imagePullSecrets:
 
 sidecar:
   version: '{{- $.Values.global.sidecar.version | default "latest" }}'
-  image: 'docker.greymatter.io/development/gm-proxy:{{ tpl $.Values.sidecar.version $ }}'
+  image: 'docker.greymatter.io/release/gm-proxy:{{ tpl $.Values.sidecar.version $ }}'
   port: 10808
   metrics_port: 8081
   imagePullPolicy: IfNotPresent

--- a/sense/Chart.yaml
+++ b/sense/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.3.0
 description: A Helm chart to deploy Grey Matter Sense
 name: sense
-version: 3.0.0
+version: 3.0.1
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
@@ -15,12 +15,12 @@ keywords:
 dependencies:
   - name: catalog
     repository: file://./catalog
-    version: '3.0.4'
+    version: '3.0.5'
 
   - name: dashboard
     repository: file://./dashboard
-    version: '3.0.1'
+    version: '3.0.2'
 
   - name: slo
     repository: file://./slo
-    version: '3.0.0'
+    version: '3.0.1'

--- a/sense/catalog/Chart.yaml
+++ b/sense/catalog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.1.0
 description: A Helm chart to deploy Grey Matter Catalog
 name: catalog
-version: 3.0.4
+version: 3.0.5
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/sense/catalog/values.yaml
+++ b/sense/catalog/values.yaml
@@ -43,8 +43,8 @@ catalog:
   # Name used for the deployment and service resources
   name: catalog
   # GM Catalog version
-  version: 1.1
-  image: docker.greymatter.io/development/gm-catalog:{{ $.Values.catalog.version }}
+  version: 1.2.2
+  image: docker.greymatter.io/release/gm-catalog:{{ $.Values.catalog.version }}
   # When to pull container images, used in the deployment
   image_pull_policy: IfNotPresent
   # CPU and memory limits for the catalog service
@@ -128,7 +128,7 @@ catalog:
       value: '/etc/pki/{{ .Values.catalog.secret.secret_keys.key }}'
 
   init:
-    image: 'docker.greymatter.io/development/gm-proxy:{{ tpl $.Values.sidecar.version $ }}'
+    image: 'docker.greymatter.io/release/gm-proxy:{{ tpl $.Values.sidecar.version $ }}'
     imagePullPolicy: IfNotPresent
     envvars:
       debug:
@@ -156,7 +156,7 @@ catalog:
 # Sidecar configuration for Catalog
 sidecar:
   version: '{{- $.Values.global.sidecar.version | default "latest" }}'
-  image: 'docker.greymatter.io/development/gm-proxy:{{ tpl $.Values.sidecar.version $ }}'
+  image: 'docker.greymatter.io/release/gm-proxy:{{ tpl $.Values.sidecar.version $ }}'
   # Port where the proxy will listen
   port: 10808
   # Port where the proxy will expose metrics

--- a/sense/dashboard/Chart.yaml
+++ b/sense/dashboard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 4.0.0
 description: A Helm chart to deploy Grey Matter Dashboard
 name: dashboard
-version: 3.0.1
+version: 3.0.2
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/sense/dashboard/values.yaml
+++ b/sense/dashboard/values.yaml
@@ -37,7 +37,7 @@ dashboard:
   name: dashboard
   # Dashboard app version
   version: 4.0.0
-  image: 'docker.greymatter.io/development/gm-dashboard:{{ $.Values.dashboard.version }}'
+  image: 'docker.greymatter.io/release/gm-dashboard:{{ $.Values.dashboard.version }}'
   # Port for the dashboard app
   port: 1337
   # When to pull container images, used in the deployment
@@ -106,7 +106,7 @@ dashboard:
 sidecar_dashboard:
   # Uses global.sidecar.version if set
   version: '{{- $.Values.global.sidecar.version | default "latest" }}'
-  image: 'docker.greymatter.io/development/gm-proxy:{{ tpl $.Values.sidecar_dashboard.version $ }}'
+  image: 'docker.greymatter.io/release/gm-proxy:{{ tpl $.Values.sidecar_dashboard.version $ }}'
   # Port where the proxy will listen
   port: 10808
   # Port where the proxy will expose metrics
@@ -174,7 +174,7 @@ prometheus:
 sidecar_prometheus:
   # Uses global.sidecar.version if set
   version: '{{- $.Values.global.sidecar.version | default "latest" }}'
-  image: 'docker.greymatter.io/development/gm-proxy:{{ tpl $.Values.sidecar_prometheus.version $ }}'
+  image: 'docker.greymatter.io/release/gm-proxy:{{ tpl $.Values.sidecar_prometheus.version $ }}'
   # Port where the proxy will listen
   port: 10808
   # Port where the proxy will expose metrics

--- a/sense/slo/Chart.yaml
+++ b/sense/slo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Grey Matter Service Level Objectives
 name: slo
-version: 3.0.0
+version: 3.0.1
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/sense/slo/values.yaml
+++ b/sense/slo/values.yaml
@@ -38,7 +38,7 @@ slo:
   name: "slo"
   # SLO version
   version: 1.2.0
-  image: "docker.greymatter.io/development/gm-slo:{{ .Values.slo.version }}"
+  image: "docker.greymatter.io/release/gm-slo:{{ .Values.slo.version }}"
   # When to pull container images, used in the deployment
   image_pull_policy: IfNotPresent
   # CPU and memory limits for the SLO service
@@ -115,7 +115,7 @@ slo:
 # Sidecar configuration for SLO
 sidecar:
   version: '{{- $.Values.global.sidecar.version | default "latest" }}'
-  image: 'docker.greymatter.io/development/gm-proxy:{{ tpl $.Values.sidecar.version $ }}'
+  image: 'docker.greymatter.io/release/gm-proxy:{{ tpl $.Values.sidecar.version $ }}'
   # Port where the proxy will listen
   port: 10808
   # Port where the proxy will expose metrics

--- a/sense/values.yaml
+++ b/sense/values.yaml
@@ -61,7 +61,7 @@ slo:
   slo:
     # SLO version
     version: 1.2.0
-    image: 'docker.greymatter.io/development/gm-slo:{{ $.Values.slo.version }}'
+    image: 'docker.greymatter.io/release/gm-slo:{{ $.Values.slo.version }}'
     # When to pull container images, used in the deployment
     image_pull_policy: IfNotPresent
     # CPU and memory limits for the SLO service
@@ -203,7 +203,7 @@ dashboard:
     name: dashboard
     # Dashboard app version
     version: "4.0.0"
-    image: 'docker.greymatter.io/development/gm-dashboard:{{ $.Values.dashboard.version }}'
+    image: 'docker.greymatter.io/release/gm-dashboard:{{ $.Values.dashboard.version }}'
     # Port for the dashboard app
     port: 1337
     # When to pull container images, used in the deployment
@@ -321,8 +321,8 @@ catalog:
     # Name used for the deployment and service resources
     name: catalog
     # GM Catalog version
-    version: 1.1
-    image: docker.greymatter.io/development/gm-catalog:{{ $.Values.catalog.version }}
+    version: 1.2.2
+    image: docker.greymatter.io/release/gm-catalog:{{ $.Values.catalog.version }}
     # When to pull container images, used in the deployment
     image_pull_policy: IfNotPresent
     # CPU and memory limits for the catalog service


### PR DESCRIPTION
This PR updates the Docker images to use the 1.3 release candidates detailed at: https://docs.greymatter.io/v/1.3-beta/release_notes. The ClickUp ticket for this is: https://app.clickup.com/t/gyuz1z

Tested the changes as a fresh install to a new EKS 1.17 cluster and everything looks good.

All pods running without issue:
```bash
[mike@orion:~/Code/release-testing]$ kc get pod
NAME                           READY   STATUS      RESTARTS   AGE
catalog-75d4c66477-5nplq       2/2     Running     0          62m
catalog-init-2fztm             0/1     Completed   0          62m
control-7cc5f658b-mg9ck        1/1     Running     0          64m
control-api-0                  2/2     Running     0          64m
control-api-init-8c27g         0/1     Completed   0          64m
dashboard-54988b585f-bs66r     2/2     Running     0          62m
data-0                         2/2     Running     0          61m
data-mongo-0                   1/1     Running     0          61m
edge-d56fd6795-7zw28           1/1     Running     0          63m
fibonacci-69b8dc85b7-lks2z     2/2     Running     0          4m33s
jwt-redis-6b84846ffc-tvch8     1/1     Running     0          64m
jwt-security-7bc8bfb9f-686v8   2/2     Running     1          64m
mesh-redis-0                   1/1     Running     0          64m
postgres-slo-0                 1/1     Running     0          62m
prometheus-0                   2/2     Running     0          62m
slo-d98698db9-bzqk4            2/2     Running     0          62m
[mike@orion:~/Code/release-testing]$
```

Images are correct:
```bash
[mike@orion:~/Code/helm-charts/data]$ for pod in $(kc get pod | grep -v NAME | awk '{ print $1 }'); do
> kc describe pod $pod | grep -i "image:"
> done
    Image:          docker.greymatter.io/internal/k8s-waiter:latest
    Image:          docker.greymatter.io/release/gm-catalog:1.2.2
    Image:          docker.greymatter.io/release/gm-proxy:1.5.1
    Image:          docker.greymatter.io/internal/k8s-waiter:latest
    Image:         docker.greymatter.io/release/gm-proxy:1.5.1
    Image:          docker.greymatter.io/internal/k8s-waiter:latest
    Image:          docker.greymatter.io/release/gm-control:1.5.1
    Image:          docker.greymatter.io/release/gm-control-api:1.5.2
    Image:          docker.greymatter.io/release/gm-proxy:1.5.1
    Image:          docker.greymatter.io/internal/k8s-waiter:latest
    Image:         docker.greymatter.io/release/greymatter:2.0.0
    Image:          docker.greymatter.io/release/gm-dashboard:4.0.0
    Image:          docker.greymatter.io/release/gm-proxy:1.5.1
    Image:          docker.greymatter.io/internal/k8s-waiter:latest
    Image:          docker.greymatter.io/release/gm-data:1.1.3
    Image:          docker.greymatter.io/release/gm-proxy:1.5.1
    Image:          deciphernow/mongo:4.0.3
    Image:          docker.greymatter.io/release/gm-proxy:1.5.1
    Image:         redis:3.2
    Image:         docker.greymatter.io/release/gm-jwt-security:1.2.0
    Image:          docker.greymatter.io/release/gm-proxy:1.5.1
    Image:         redis:3.2
    Image:          docker.io/centos/postgresql-10-centos7
    Image:         prom/prometheus:v2.7.1
    Image:          docker.greymatter.io/release/gm-proxy:1.5.1
    Image:          docker.greymatter.io/internal/k8s-waiter:latest
    Image:          docker.greymatter.io/release/gm-slo:1.2.0
    Image:          docker.greymatter.io/release/gm-proxy:1.5.1
[mike@orion:~/Code/helm-charts/data]$
```

I ran through the following tests on the new images:
 - Installed and successfully tested gm-data. I was able to upload and stream documents.
 - Installed the Fibonacci service and confirmed that its API endpoint is working.
 - Tested the SLOs and Business Impacts by modifying and confirming that they are persisted in PostGres/Redis.
