### PR TITLE
Remove rolebinding before Sense upgrade (#826)

### DIFF
--- a/sense/Makefile
+++ b/sense/Makefile
@@ -23,6 +23,9 @@ dashboard: wsa-sense
 slo: wsa-sense
 	helm install $(NAME-SENSE) slo $(WAITERSACHECK-SENSE) -f ../global.yaml
 
+rolebinding:
+	kubectl delete rolebinding prometheus-sa-rolebinding
+
 clean-sense:
 	rm -f ./charts/*
 
@@ -38,7 +41,7 @@ sense: package-sense wsa-sense
 	helm install $(NAME-SENSE) . $(WAITERSACHECK-SENSE) -f ../global.yaml --timeout 10m --wait
 
 .PHONY: upgrade-sense
-upgrade-sense: wsa-sense package-sense helm-validator
+upgrade-sense: wsa-sense package-sense helm-validator rolebinding
 	helm upgrade $(NAME-SENSE) . $(WAITERSACHECK-SENSE) -f ../global.yaml --no-hooks --install $(HELM_VALIDATION)
 
 .PHONY: remove-sense


### PR DESCRIPTION
Update to `sense/Makefile` to delete the `prometheus-sa-rolebinding` prior to `make upgrade-sense`. This is to address issue #826 

`make upgrade-sense` is successful with the changes:
```bash
[mike@orion:~/Code/helm-charts/sense]$ make upgrade-sense
rm -f ./charts/*
helm dep up .
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "greymatter" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 3 charts
Deleting outdated charts
--disable-openapi-validation
kubectl delete rolebinding prometheus-sa-rolebinding
rolebinding.rbac.authorization.k8s.io "prometheus-sa-rolebinding" deleted
helm upgrade sense . --set=global.waiter.service_account.create=false -f ../global.yaml --no-hooks --install --disable-openapi-validation
Release "sense" has been upgraded. Happy Helming!
NAME: sense
LAST DEPLOYED: Mon Dec  7 14:13:09 2020
NAMESPACE: default
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
Grey Matter 3.0.1 has been installed.

sense deployed to namespace "default" at 02:13:09 on 12/07/02


NOTE: It may take a few minutes for the installation to become stable.
    You can watch the status of the pods by running 'kubectl get pods -w -n default'
[mike@orion:~/Code/helm-charts/sense]$
```