### PR TITLE
Prometheus role lookup

### DIFF
--- a/sense/Chart.yaml
+++ b/sense/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.3.0
 description: A Helm chart to deploy Grey Matter Sense
 name: sense
-version: 3.0.1
+version: 3.0.2
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
@@ -19,7 +19,7 @@ dependencies:
 
   - name: dashboard
     repository: file://./dashboard
-    version: '3.0.2'
+    version: '3.0.3'
 
   - name: slo
     repository: file://./slo

--- a/sense/Makefile
+++ b/sense/Makefile
@@ -37,8 +37,22 @@ template-sense: package-sense $(BUILD_NUMBER_FILE)
 sense: package-sense wsa-sense
 	helm install $(NAME-SENSE) . $(WAITERSACHECK-SENSE) -f ../global.yaml --timeout 10m --wait
 
+	
+check-prom-rb:
+	$(eval CURRENT_KIND=$(shell kubectl get RoleBinding prometheus-sa-rolebinding -o json | jq -r '.roleRef.kind'))
+	$(eval DESIRED_KIND=$(shell cat dashboard/values.yaml | yq -r '.prometheus.service_account.kind'))
+	if [ -z "$(CURRENT_KIND)" ] || [ "$(DESIRED_KIND)" == "$(CURRENT_KIND)" ]; then \
+		echo "They Match or current kind does not exist"; \
+	else \
+		# echo "The current prometheus rolebinding does not match the kind that you are trying to upgrade too.  "; \
+		# echo "This requires manually deleting the role and rolebinding with: "; \
+		# echo "kubectl delete RoleBinding prometheus-sa-rolebinding"; \
+		# exit 3; \
+		kubectl delete RoleBinding prometheus-sa-rolebinding; \
+	fi
+
 .PHONY: upgrade-sense
-upgrade-sense: wsa-sense package-sense helm-validator
+upgrade-sense: wsa-sense package-sense helm-validator check-prom-rb
 	helm upgrade $(NAME-SENSE) . $(WAITERSACHECK-SENSE) -f ../global.yaml --no-hooks --install $(HELM_VALIDATION)
 
 .PHONY: remove-sense

--- a/sense/Makefile
+++ b/sense/Makefile
@@ -39,8 +39,8 @@ sense: package-sense wsa-sense
 
 	
 check-prom-rb:
-	$(eval CURRENT_KIND=$(shell kubectl get RoleBinding prometheus-sa-rolebinding -o json | jq -r '.roleRef.kind'))
-	$(eval DESIRED_KIND=$(shell cat dashboard/values.yaml | yq -r '.prometheus.service_account.kind'))
+	$(eval CURRENT_KIND=$(shell kubectl get RoleBinding prometheus-sa-rolebinding -o json | docker run -i --entrypoint jq docker.greymatter.io/internal/yq:2.4.1 -r '.roleRef.kind'))
+	$(eval DESIRED_KIND=$(shell cat values.yaml | docker run -i docker.greymatter.io/internal/yq:2.4.1 -r '.dashboard.prometheus.service_account.kind'))
 	if [ -z "$(CURRENT_KIND)" ] || [ "$(DESIRED_KIND)" == "$(CURRENT_KIND)" ]; then \
 		echo "They Match or current kind does not exist"; \
 	else \

--- a/sense/dashboard/Chart.yaml
+++ b/sense/dashboard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 4.0.0
 description: A Helm chart to deploy Grey Matter Dashboard
 name: dashboard
-version: 3.0.2
+version: 3.0.3
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/sense/dashboard/templates/_helpers.tpl
+++ b/sense/dashboard/templates/_helpers.tpl
@@ -15,3 +15,24 @@ Create the namespace list for Prometheus to monitor
 {{- println $d -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+define role name
+*/}}
+{{- define "prometheus.role.name" -}}
+{{ printf "%s-%s" .Values.prometheus.service_account.name "role" }}
+{{- end -}}
+
+{{/*
+define primary namespace rolebinding name
+*/}}
+{{- define "prometheus.rolebinding.name" -}}
+{{ printf "%s-%s" .Values.prometheus.service_account.name "rolebinding" }}
+{{- end -}}
+
+{{/*
+define additional namespace rolebinding name
+*/}}
+{{- define "prometheus.rolebinding.additional.name" -}}
+{{ printf "%s-%s-%s" .Values.prometheus.service_account.name "rolebinding" "$e" }}
+{{- end -}}

--- a/sense/dashboard/templates/role.yaml
+++ b/sense/dashboard/templates/role.yaml
@@ -1,11 +1,17 @@
 {{- if .Values.prometheus.service_account.create }}
-kind: ClusterRole
+{{- $roleName := (include "prometheus.role.name" .) }}
+{{- $rb := (lookup "v1" .Values.prometheus.service_account.kind .Release.Namespace $roleName) -}}
+{{- if not $rb }}
+kind: {{.Values.prometheus.service_account.kind }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.prometheus.service_account.name }}-role
+  name: {{ $roleName }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    rollme: {{ randAlphaNum 5 | quote }}
 rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs: ["get", "list", "watch"]
+{{- end }}
 {{- end }}

--- a/sense/dashboard/templates/rolebinding.yaml
+++ b/sense/dashboard/templates/rolebinding.yaml
@@ -1,38 +1,53 @@
 {{- if .Values.prometheus.service_account.create }}
+{{- $roleName := (include "prometheus.role.name" .) }}
+{{- $roleBindingName := (include "prometheus.rolebinding.name" .) }}
+{{- $rb := (lookup "v1" "RoleBinding" .Release.Namespace $roleBindingName) -}}
+{{- if not $rb }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ .Values.prometheus.service_account.name }}-rolebinding
+  name: {{ $roleBindingName }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    rollme: {{ randAlphaNum 5 | quote }}
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.prometheus.service_account.name }}
   namespace: {{ .Release.Namespace }}
 roleRef:
-  kind: ClusterRole
-  name: {{ .Values.prometheus.service_account.name }}-role
+  kind: {{ .Values.prometheus.service_account.kind }}
+  name: {{ $roleName }}
   apiGroup: rbac.authorization.k8s.io
+
+{{- end }}
 
 {{- if .Values.global.control.additional_namespaces }}
 {{- $sa_name := .Values.prometheus.service_account.name -}}
 {{- $release_ns := .Release.Namespace -}}
+{{- $root := . -}}
 {{- range $ns, $e := splitList "," $.Values.global.control.additional_namespaces }}
 
+{{- $roleBindingName := (include "prometheus.rolebinding.additional.name" $root) }}
+{{- $rb := (lookup "v1" "RoleBinding" .Release.Namespace $roleBindingName) -}}
+{{- if not $rb }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ $sa_name }}-rolebinding-{{ $e }}
+  name: {{ $roleBindingName }}
   namespace: {{ $e }}
+  annotations:
+    rollme: {{ randAlphaNum 5 | quote }}
 subjects:
 - kind: ServiceAccount
   name: {{ $sa_name }}
   namespace: {{ $release_ns }}
 roleRef:
-  kind: ClusterRole
-  name: {{ $sa_name }}-role
+  kind: {{ .Values.prometheus.service_account.kind }}
+  name: {{ $roleName }}
   apiGroup: rbac.authorization.k8s.io
+{{- end -}}
 {{- end -}}
 {{- end }}
 

--- a/sense/dashboard/values.yaml
+++ b/sense/dashboard/values.yaml
@@ -161,6 +161,8 @@ prometheus:
   service_account:
     create: true
     name: prometheus-sa
+    # kind specifies either ClusterRole or Role
+    kind: ClusterRole
   resources:
     requests:
       memory: "8Gi"

--- a/sense/values.yaml
+++ b/sense/values.yaml
@@ -301,6 +301,8 @@ dashboard:
     service_account:
       create: true
       name: prometheus-sa
+      # kind specifies either ClusterRole or Role
+      kind: ClusterRole
     resources:
       requests:
         memory: "8Gi"


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

This PR allows the installer to move between role and clusterrole for the prometheus sa without a manual delete step.  It picks up on the difference inside the mesh vs the dashboard values file and will usurp what is currently in the cluster with whatever is in the values file (by removing the old rolebinding then installing a fresh one as part of the upgrade process).

2. What **changes to custom.yaml** are required?

`sense/dashboard/values.yaml` has an additional field prometheus.service_account.kind can be either Role or ClusterRole

3. Have you documented any additional setup steps or configurations options?

<br/><br/>

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

you can run a `make sense` then change prometheus.service_account.kind and run `make upgrade-sense` and the rolebinding will be deleted before the change. 
