### PR TITLE
Make it easier to copy and paste commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ make credentials
 The following set of commands will install Grey Matter using the GitHub hosted Helm Charts.
 
 ```console
-$ helm install secrets greymatter/secrets -f credentials.yaml -f global.yaml
-$ helm install spire greymatter/spire --set=global.environment=kubernetes -f global.yaml
-$ helm install fabric greymatter/fabric --set=global.environment=kubernetes -f global.yaml
-$ helm install edge greymatter/edge --set=edge.ingress.type=LoadBalancer -f global.yaml
-$ helm install sense greymatter/sense -f global.yaml --set=global.waiter.service_account.create=false
+helm install secrets greymatter/secrets -f credentials.yaml -f global.yaml
+helm install spire greymatter/spire --set=global.environment=kubernetes -f global.yaml
+helm install fabric greymatter/fabric --set=global.environment=kubernetes -f global.yaml
+helm install edge greymatter/edge --set=edge.ingress.type=LoadBalancer -f global.yaml
+helm install sense greymatter/sense -f global.yaml --set=global.waiter.service_account.create=false
 ```
 
 ### Viewing the Grey Matter Application


### PR DESCRIPTION
This change allows copying and pasting the helm commands in one go, and matches the style of the rest of the README.
