### PR TITLE
removed extra domains from edge and edge-egress listeners

### DIFF
--- a/fabric/Chart.yaml
+++ b/fabric/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
 dependencies:
   - name: control-api
     repository: file://./control-api
-    version: '3.0.9'
+    version: '3.0.10'
 
   - name: control
     repository: file://./control

--- a/fabric/control-api/Chart.yaml
+++ b/fabric/control-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.5.4
 description: Deploys the Grey Matter 2.0 control-api mesh-wide configuration API
 name: control-api
-version: 3.0.9
+version: 3.0.10
 home: https://greymatter.io
 maintainers:
   - name: greymatter-io

--- a/fabric/control-api/json/special/listener-egress.json
+++ b/fabric/control-api/json/special/listener-egress.json
@@ -1,7 +1,7 @@
 {
   "zone_key": "{{ .Values.global.zone}}",
   "listener_key": "edge-listener-egress",
-  "domain_keys": ["edge", "edge-egress"],
+  "domain_keys": ["edge-egress"],
   "name": "edge",
   "ip": "127.0.0.1",
   "port": 10909,

--- a/fabric/control-api/json/special/listener.json
+++ b/fabric/control-api/json/special/listener.json
@@ -1,7 +1,7 @@
 {
   "zone_key": "{{ .Values.global.zone}}",
   "listener_key": "edge-listener",
-  "domain_keys": ["edge", "edge-egress"],
+  "domain_keys": ["edge"],
   "name": "edge",
   "ip": "0.0.0.0",
   "port": 10808,


### PR DESCRIPTION
closes https://github.com/greymatter-io/helm-charts/issues/843

**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

- remove edge egress domain from edge listener
- remove edge domain from edge egress listener

<br/><br/>

2. What **changes to custom.yaml** are required?

none

<br/><br/>

3. Have you documented any additional setup steps or configurations options?

n/a

<br/><br/>

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

<br/><br/>
Our routes were getting messed since all edge listeners were referencing the edge and edge-egress domains. See the config pane here: https://gm-one-three.greymatter.services/#/?ascending=true&configPaneOpen=true&configPaneService=edge&displayType=Cards&groupByAttribute=Status&mode=dark&searchQuery=&sortByAttribute=Name

When the edge domains are separated out, this is resolved. See this test cluster I deployed: https://internal-afcf1f3bb1562457b9d51530cb57df9e-2146952044.us-east-1.elb.amazonaws.com:10808/#/?ascending=true&configPaneOpen=true&configPaneService=edge&displayType=Cards&groupByAttribute=Status&mode=light&searchQuery=&sortByAttribute=Name



