### PR TITLE
2.4 update tags spire publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,13 +37,16 @@ jobs:
           echo "$(awk 'NR==1,/name: jwt/{sub(/name: jwt/, "name: jwt-gov")} 1' fabric-gov/Chart.yaml)" > fabric-gov/Chart.yaml
           sed -i -e "s|name: fabric|name: fabric-gov|" -e "s|Grey Matter Fabric|Grey Matter Fabric Gov|" -e "s|/jwt|/jwt-gov|" fabric-gov/Chart.yaml
 
-      - name: Run Grey Matter Charts
+      - name: Release Spire Server and Agent Charts
+        uses: helm/chart-releaser-action@v1.0.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          charts_dir: spire
+
+      - name: Release Grey Matter Charts
         uses: helm/chart-releaser-action@v1.0.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           charts_dir: .
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -70,6 +70,35 @@ Integration tests are run automatically upon pull requests; however, you can emu
     go test -v greymatter_integration_test.go
     ```
 
+## Development
+
+Current Release Branch: `release-2.3`
+Future Release Branch: `release-2.4`
+
+>*If changes are made to the current release branch make sure to ensure corresponding changes are made to the future release branch*
+
+### Versioning
+
+Grey Matter Helm Charts follow semver principals and allow us to manage active development for current and future releases.  Pre-release charts will have a suffix of `-x` which indicates to helm that this is a prerelease chart.  These are not used for installation or dependency fulfillment unless specifically called out.
+
+Any change to the Helm Chart templates or values files will require the chart version to be incremented in order to pass ci/cd linting.
+
+**General guidance for release/ tag versioning:**
+
+*Increment Major:*
+If a helm release can not be upgraded using a `helm upgrade <release_name>`
+Adding or major charts
+
+*Increment Minor:*
+Addition, removal, substitution of values files and/or templates have changes that make them incompatible with older values files
+
+*Increment Patch:*
+Template logic changes which do not result in modifications to values files (are backwards compatible)
+
+### Release Tagging
+
+Releases will be tagged periodically and will be based off the release branch.  For `release-2.4` branch we will tag `2.4.x`.
+
 ## More Documentation
 
 Additional information on the Helm Charts and Grey Matter configuration can be found in the links below.

--- a/edge/Chart.yaml
+++ b/edge/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.1
 description: A Helm chart to deploy Grey Matter Edge
 name: edge
-version: 3.0.2-alpha
+version: 3.0.2-0
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: greymatter-io

--- a/edge/Chart.yaml
+++ b/edge/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.1
 description: A Helm chart to deploy Grey Matter Edge
 name: edge
-version: 3.0.2
+version: 3.0.2-alpha
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: greymatter-io

--- a/edge/Chart.yaml
+++ b/edge/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.1
 description: A Helm chart to deploy Grey Matter Edge
 name: edge
-version: 3.0.2-0
+version: 3.0.3-0
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: greymatter-io

--- a/fabric/Chart.yaml
+++ b/fabric/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.3.0
 description: A Helm chart to deploy Grey Matter Fabric
 name: fabric
-version: 3.0.4-0
+version: 3.0.5-0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
@@ -15,18 +15,18 @@ keywords:
 dependencies:
   - name: control-api
     repository: file://./control-api
-    version: '3.0.10-0'
+    version: '3.0.11-0'
 
   - name: control
     repository: file://./control
-    version: '3.0.2-0'
+    version: '3.0.3-0'
 
   - name: jwt
     repository: file://./jwt
-    version: '3.0.1-0'
+    version: '3.0.2-0'
 
   - name: redis
     repository: file://./redis
-    version: '1.0.2-0'
+    version: '1.0.3-0'
     condition: global.external_redis.disabled
     alias: mesh-redis

--- a/fabric/Chart.yaml
+++ b/fabric/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.3.0
 description: A Helm chart to deploy Grey Matter Fabric
 name: fabric
-version: 3.0.4
+version: 3.0.4-alpha
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
@@ -15,18 +15,18 @@ keywords:
 dependencies:
   - name: control-api
     repository: file://./control-api
-    version: '3.0.10'
+    version: '3.0.10-alpha'
 
   - name: control
     repository: file://./control
-    version: '3.0.2'
+    version: '3.0.2-alpha'
 
   - name: jwt
     repository: file://./jwt
-    version: '3.0.1'
+    version: '3.0.1-alpha'
 
   - name: redis
     repository: file://./redis
-    version: '1.0.2'
+    version: '1.0.2-alpha'
     condition: global.external_redis.disabled
     alias: mesh-redis

--- a/fabric/Chart.yaml
+++ b/fabric/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.3.0
 description: A Helm chart to deploy Grey Matter Fabric
 name: fabric
-version: 3.0.4-alpha
+version: 3.0.4-0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
@@ -15,18 +15,18 @@ keywords:
 dependencies:
   - name: control-api
     repository: file://./control-api
-    version: '3.0.10-alpha'
+    version: '3.0.10-0'
 
   - name: control
     repository: file://./control
-    version: '3.0.2-alpha'
+    version: '3.0.2-0'
 
   - name: jwt
     repository: file://./jwt
-    version: '3.0.1-alpha'
+    version: '3.0.1-0'
 
   - name: redis
     repository: file://./redis
-    version: '1.0.2-alpha'
+    version: '1.0.2-0'
     condition: global.external_redis.disabled
     alias: mesh-redis

--- a/fabric/control-api/Chart.yaml
+++ b/fabric/control-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.5.4
 description: Deploys the Grey Matter 2.0 control-api mesh-wide configuration API
 name: control-api
-version: 3.0.10-0
+version: 3.0.11-0
 home: https://greymatter.io
 maintainers:
   - name: greymatter-io

--- a/fabric/control-api/Chart.yaml
+++ b/fabric/control-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.5.4
 description: Deploys the Grey Matter 2.0 control-api mesh-wide configuration API
 name: control-api
-version: 3.0.10
+version: 3.0.10-alpha
 home: https://greymatter.io
 maintainers:
   - name: greymatter-io

--- a/fabric/control-api/Chart.yaml
+++ b/fabric/control-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.5.4
 description: Deploys the Grey Matter 2.0 control-api mesh-wide configuration API
 name: control-api
-version: 3.0.10-alpha
+version: 3.0.10-0
 home: https://greymatter.io
 maintainers:
   - name: greymatter-io

--- a/fabric/control/Chart.yaml
+++ b/fabric/control/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.5.3
 description: Deploys the Grey Matter 2.0 control server
 name: control
 home: https://greymatter.io
-version: 3.0.2-alpha
+version: 3.0.2-0
 maintainers:
   - name: greymatter-io
     email: engineering@greymatter.io

--- a/fabric/control/Chart.yaml
+++ b/fabric/control/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.5.3
 description: Deploys the Grey Matter 2.0 control server
 name: control
 home: https://greymatter.io
-version: 3.0.2-0
+version: 3.0.3-0
 maintainers:
   - name: greymatter-io
     email: engineering@greymatter.io

--- a/fabric/control/Chart.yaml
+++ b/fabric/control/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.5.3
 description: Deploys the Grey Matter 2.0 control server
 name: control
 home: https://greymatter.io
-version: 3.0.2
+version: 3.0.2-alpha
 maintainers:
   - name: greymatter-io
     email: engineering@greymatter.io

--- a/fabric/jwt-gov/Chart.yaml
+++ b/fabric/jwt-gov/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Grey Matter JWT Security Gov
 name: jwt-gov
-version: 3.0.1-0
+version: 3.0.4-0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/fabric/jwt-gov/Chart.yaml
+++ b/fabric/jwt-gov/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Grey Matter JWT Security Gov
 name: jwt-gov
-version: 3.0.1-alpha
+version: 3.0.1-0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/fabric/jwt-gov/Chart.yaml
+++ b/fabric/jwt-gov/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Grey Matter JWT Security Gov
 name: jwt-gov
-version: 3.0.1
+version: 3.0.1-alpha
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/fabric/jwt/Chart.yaml
+++ b/fabric/jwt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Grey Matter JWT Security
 name: jwt
-version: 3.0.1
+version: 3.0.1-alpha
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/fabric/jwt/Chart.yaml
+++ b/fabric/jwt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Grey Matter JWT Security
 name: jwt
-version: 3.0.1-0
+version: 3.0.2-0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/fabric/jwt/Chart.yaml
+++ b/fabric/jwt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Grey Matter JWT Security
 name: jwt
-version: 3.0.1-alpha
+version: 3.0.1-0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/fabric/redis/Chart.yaml
+++ b/fabric/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.0.0
 description: A Helm chart to deploy a Redis server to be used by Control API and Catalog
 name: redis
-version: 1.0.2
+version: 1.0.2-alpha
 home: https://greymatter.io
 maintainers:
   - name: greymatter-io

--- a/fabric/redis/Chart.yaml
+++ b/fabric/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.0.0
 description: A Helm chart to deploy a Redis server to be used by Control API and Catalog
 name: redis
-version: 1.0.2-0
+version: 1.0.3-0
 home: https://greymatter.io
 maintainers:
   - name: greymatter-io

--- a/fabric/redis/Chart.yaml
+++ b/fabric/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.0.0
 description: A Helm chart to deploy a Redis server to be used by Control API and Catalog
 name: redis
-version: 1.0.2-alpha
+version: 1.0.2-0
 home: https://greymatter.io
 maintainers:
   - name: greymatter-io

--- a/secrets/Chart.yaml
+++ b/secrets/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy secrets
 name: secrets
-version: 2.3.0-0
+version: 2.3.1-0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/secrets/Chart.yaml
+++ b/secrets/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy secrets
 name: secrets
-version: 2.3.0-alpha
+version: 2.3.0-0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/secrets/Chart.yaml
+++ b/secrets/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy secrets
 name: secrets
-version: 2.3.0
+version: 2.3.0-alpha
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/sense/Chart.yaml
+++ b/sense/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.3.0
 description: A Helm chart to deploy Grey Matter Sense
 name: sense
-version: 3.0.4-alpha
+version: 3.0.4-0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
@@ -15,12 +15,12 @@ keywords:
 dependencies:
   - name: catalog
     repository: file://./catalog
-    version: '3.0.8-alpha'
+    version: '3.0.8-0'
 
   - name: dashboard
     repository: file://./dashboard
-    version: '3.0.3-alpha'
+    version: '3.0.3-0'
 
   - name: slo
     repository: file://./slo
-    version: '3.0.1-alpha'
+    version: '3.0.1-0'

--- a/sense/Chart.yaml
+++ b/sense/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.3.0
 description: A Helm chart to deploy Grey Matter Sense
 name: sense
-version: 3.0.4-0
+version: 3.0.5-0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
@@ -15,12 +15,12 @@ keywords:
 dependencies:
   - name: catalog
     repository: file://./catalog
-    version: '3.0.8-0'
+    version: '3.0.9-0'
 
   - name: dashboard
     repository: file://./dashboard
-    version: '3.0.3-0'
+    version: '3.0.4-0'
 
   - name: slo
     repository: file://./slo
-    version: '3.0.1-0'
+    version: '3.0.2-0'

--- a/sense/Chart.yaml
+++ b/sense/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.3.0
 description: A Helm chart to deploy Grey Matter Sense
 name: sense
-version: 3.0.4
+version: 3.0.4-alpha
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
@@ -15,12 +15,12 @@ keywords:
 dependencies:
   - name: catalog
     repository: file://./catalog
-    version: '3.0.8'
+    version: '3.0.8-alpha'
 
   - name: dashboard
     repository: file://./dashboard
-    version: '3.0.3'
+    version: '3.0.3-alpha'
 
   - name: slo
     repository: file://./slo
-    version: '3.0.1'
+    version: '3.0.1-alpha'

--- a/sense/catalog/Chart.yaml
+++ b/sense/catalog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.1.0
 description: A Helm chart to deploy Grey Matter Catalog
 name: catalog
-version: 3.0.8
+version: 3.0.8-alpha
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/sense/catalog/Chart.yaml
+++ b/sense/catalog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.1.0
 description: A Helm chart to deploy Grey Matter Catalog
 name: catalog
-version: 3.0.8-alpha
+version: 3.0.8-0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/sense/catalog/Chart.yaml
+++ b/sense/catalog/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.1.0
 description: A Helm chart to deploy Grey Matter Catalog
 name: catalog
-version: 3.0.8-0
+version: 3.0.9-0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/sense/dashboard/Chart.yaml
+++ b/sense/dashboard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 4.0.1
 description: A Helm chart to deploy Grey Matter Dashboard
 name: dashboard
-version: 3.0.3
+version: 3.0.3-alpha
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/sense/dashboard/Chart.yaml
+++ b/sense/dashboard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 4.0.1
 description: A Helm chart to deploy Grey Matter Dashboard
 name: dashboard
-version: 3.0.3-0
+version: 3.0.4-0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/sense/dashboard/Chart.yaml
+++ b/sense/dashboard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 4.0.1
 description: A Helm chart to deploy Grey Matter Dashboard
 name: dashboard
-version: 3.0.3-alpha
+version: 3.0.3-0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/sense/slo/Chart.yaml
+++ b/sense/slo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Grey Matter Service Level Objectives
 name: slo
-version: 3.0.1-alpha
+version: 3.0.1-0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/sense/slo/Chart.yaml
+++ b/sense/slo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Grey Matter Service Level Objectives
 name: slo
-version: 3.0.1
+version: 3.0.1-alpha
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/sense/slo/Chart.yaml
+++ b/sense/slo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Grey Matter Service Level Objectives
 name: slo
-version: 3.0.1-0
+version: 3.0.2-0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/spire/Chart.yaml
+++ b/spire/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Spire
 name: spire
-version: 2.2.3
+version: 2.2.4-alpha
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
@@ -16,8 +16,8 @@ keywords:
 dependencies:
   - name: agent
     repository: file://./agent
-    version: '2.2.4'
+    version: '2.2.5-alpha'
 
   - name: server
     repository: file://./server
-    version: '2.2.4'
+    version: '2.2.5-alpha'

--- a/spire/Chart.yaml
+++ b/spire/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Spire
 name: spire
-version: 2.2.4-alpha
+version: 2.2.4-0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
@@ -16,8 +16,8 @@ keywords:
 dependencies:
   - name: agent
     repository: file://./agent
-    version: '2.2.5-alpha'
+    version: '2.2.5-0'
 
   - name: server
     repository: file://./server
-    version: '2.2.5-alpha'
+    version: '2.2.5-0'

--- a/spire/Chart.yaml
+++ b/spire/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Spire
 name: spire
-version: 2.2.4-0
+version: 2.2.5-0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
@@ -16,8 +16,8 @@ keywords:
 dependencies:
   - name: agent
     repository: file://./agent
-    version: '2.2.5-0'
+    version: '2.2.6-0'
 
   - name: server
     repository: file://./server
-    version: '2.2.5-0'
+    version: '2.2.6-0'

--- a/spire/agent/Chart.yaml
+++ b/spire/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy the Spire Agent
 name: agent
-version: "2.2.5-alpha"
+version: 2.2.5-0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/spire/agent/Chart.yaml
+++ b/spire/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy the Spire Agent
 name: agent
-version: 2.2.4
+version: 2.2.5
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/spire/agent/Chart.yaml
+++ b/spire/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy the Spire Agent
 name: agent
-version: 2.2.5-0
+version: 2.2.6-0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/spire/agent/Chart.yaml
+++ b/spire/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy the Spire Agent
 name: agent
-version: 2.2.5
+version: "2.2.5-alpha"
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/spire/server/Chart.yaml
+++ b/spire/server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy the Spire Server
 name: server
-version: 2.2.5-0
+version: 2.2.6-0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/spire/server/Chart.yaml
+++ b/spire/server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy the Spire Server
 name: server
-version: 2.2.4
+version: 2.2.5
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/spire/server/Chart.yaml
+++ b/spire/server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy the Spire Server
 name: server
-version: 2.2.5
+version: 2.2.5-0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

This PR:
- adds the ability to publish spire agent and server charts like in release-2.3
- appends `-0` to all chart versions.

Per semver the `-x` is designates the chart as a pre release and the charts published will not be used when a version is not specified on a helm install for remote charts

ex: `helm install fabric greymatter/fabric` will install the latest release; whereas `helm install fabric greymatter/fabric --version 3.0.4-0` will install the pre release built when merging to release-2.4 branch

2. What **changes to custom.yaml** are required?

none

3. Have you documented any additional setup steps or configurations options?

the versioning info is in the readme

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

I have run this against a k3d instance.  Post merge i will test the newly published charts.
