### PR TITLE
Update the linters to catch when an umbrella chart needs to be updated

### DIFF
--- a/.chart-testing/fabric-sense-data.yaml
+++ b/.chart-testing/fabric-sense-data.yaml
@@ -1,6 +1,3 @@
-charts:
-  - fabric
-  - sense
-  - data
-  - spire
+chart-dirs:
+  - .
 target-branch: release-2.3

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -43,6 +43,23 @@ jobs:
       - name: Fetch history
         run: git fetch --prune --unshallow
 
+      - name: Download helm
+        env:
+          helm_version: 3.3.4
+        run: |
+          # get helm
+          wget "https://get.helm.sh/helm-v${helm_version}-linux-amd64.tar.gz"
+          tar -xvf helm-v${helm_version}-linux-amd64.tar.gz
+          chmod +s linux-amd64/helm
+          sudo mv linux-amd64/helm /usr/local/
+
+      - name: Run helm dep up
+        run: |
+          helm dep up fabric
+          helm dep up spire
+          helm dep up sense
+          helm dep up data
+
       - name: Run chart-testing (lint fabric sense data)
         id: lint-fabric-sense-data
         uses: helm/chart-testing-action@v1.0.0

--- a/fabric/control-api/Chart.yaml
+++ b/fabric/control-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.5.4
 description: Deploys the Grey Matter 2.0 control-api mesh-wide configuration API
 name: control-api
-version: 3.0.13
+version: 3.0.12
 home: https://greymatter.io
 maintainers:
   - name: greymatter-io

--- a/fabric/control-api/Chart.yaml
+++ b/fabric/control-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.5.4
 description: Deploys the Grey Matter 2.0 control-api mesh-wide configuration API
 name: control-api
-version: 3.0.12
+version: 3.0.13
 home: https://greymatter.io
 maintainers:
   - name: greymatter-io


### PR DESCRIPTION
This PR fixes the umbrella chart linting.  It adjusts two things:
* installs helm and runs a `helm dep up` for the umbrella charts
* updates the umbrella config file 

You can see a successful capture of the need to update an umbrella chart here: https://github.com/greymatter-io/helm-charts/runs/1750370868?check_suite_focus=true

And then a successful run of the linter, https://github.com/greymatter-io/helm-charts/actions/runs/504268990

closes #854 
