### PR TITLE
Add sidecar proxy onto control

### DIFF
--- a/catalog-egress-mesh-objects/apply.sh
+++ b/catalog-egress-mesh-objects/apply.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+for cl in clusters/*.json; do greymatter create cluster < $cl; done
+for cl in domains/*.json; do greymatter create domain < $cl; done
+for cl in listeners/*.json; do greymatter create listener < $cl; done
+for cl in proxies/*.json; do greymatter create proxy < $cl; done
+for cl in rules/*.json; do greymatter create shared_rules < $cl; done
+for cl in routes/*.json; do greymatter create route < $cl; done
+
+curl -k -XPOST --cert $GREYMATTER_API_SSLCERT --key $GREYMATTER_API_SSLKEY https://$GREYMATTER_API_HOST/services/catalog/latest/clusters -d "@catalog/catalog.json"

--- a/catalog-egress-mesh-objects/catalog/catalog.json
+++ b/catalog-egress-mesh-objects/catalog/catalog.json
@@ -1,0 +1,21 @@
+{
+  "clusterName": "catalog",
+  "zoneName": "zone-default-zone",
+  "name": "Catalog",
+  "version": "latest",
+  "owner": "",
+  "capability": "Mesh",
+  "runtime": "GO",
+  "documentation": "",
+  "prometheusJob": "catalog",
+  "minInstances": 1,
+  "maxInstances": 1,
+  "authorized": true,
+  "clusterID": "",
+  "meshID": "",
+  "enableInstanceMetrics": true,
+  "enableHistoricalMetrics": true,
+  "instances": [],
+  "metricsTemplate": "",
+  "metricsPort": 8081
+}

--- a/catalog-egress-mesh-objects/clusters/edge.json
+++ b/catalog-egress-mesh-objects/clusters/edge.json
@@ -1,0 +1,20 @@
+{
+    "zone_key": "zone-default-zone",
+    "cluster_key": "edge-to-catalog-cluster",
+    "name": "catalog",
+    "instances": [],
+    "circuit_breakers": null,
+    "outlier_detection": null,
+    "health_checks": [],
+    "require_tls": true,
+    "ssl_config": {
+        "require_client_certs": true,
+        "trust_file": "/etc/proxy/tls/sidecar/ca.crt",
+        "cert_key_pairs": [
+          {
+            "certificate_path": "/etc/proxy/tls/sidecar/server.crt",
+            "key_path": "/etc/proxy/tls/sidecar/server.key"
+          }
+        ]
+      }
+}

--- a/catalog-egress-mesh-objects/clusters/egress-cluster.json
+++ b/catalog-egress-mesh-objects/clusters/egress-cluster.json
@@ -1,0 +1,20 @@
+{
+    "zone_key": "zone-default-zone",
+    "cluster_key": "catalog-control-cluster",
+    "name": "control",
+    "instances": [],
+    "require_tls": true,
+    "http2_protocol_options": {
+      "allow_connect": true
+    },
+    "ssl_config": {
+      "require_client_certs": true,
+      "trust_file": "/etc/proxy/tls/sidecar/ca.crt",
+      "cert_key_pairs": [
+        {
+          "certificate_path": "/etc/proxy/tls/sidecar/server.crt",
+          "key_path": "/etc/proxy/tls/sidecar/server.key"
+        }
+      ]
+    }
+  }

--- a/catalog-egress-mesh-objects/clusters/local.json
+++ b/catalog-egress-mesh-objects/clusters/local.json
@@ -1,0 +1,14 @@
+{
+    "zone_key": "zone-default-zone",
+    "cluster_key": "cluster-catalog-local",
+    "name": "catalog-local",
+    "instances": [
+        {
+            "host": "127.0.0.1",
+            "port": 9080
+        }
+    ],
+    "circuit_breakers": null,
+    "outlier_detection": null,
+    "health_checks": []
+}

--- a/catalog-egress-mesh-objects/domains/egress.json
+++ b/catalog-egress-mesh-objects/domains/egress.json
@@ -1,0 +1,17 @@
+{
+    "zone_key": "zone-default-zone",
+    "domain_key": "domain-catalog-egress",
+    "name": "*",
+    "port": 10909,
+    "redirects": null,
+    "gzip_enabled": false,
+    "cors_config": null,
+    "aliases": null,
+    "force_https": false,
+    "custom_headers": [
+        {
+          "key": "x-forwarded-proto",
+          "value": "https"
+        }
+    ]
+}

--- a/catalog-egress-mesh-objects/domains/ingress.json
+++ b/catalog-egress-mesh-objects/domains/ingress.json
@@ -1,0 +1,21 @@
+{
+    "zone_key": "zone-default-zone",
+    "domain_key": "domain-catalog-ingress",
+    "name": "*",
+    "port": 10808,
+    "redirects": null,
+    "gzip_enabled": false,
+    "cors_config": null,
+    "aliases": null,
+    "ssl_config": {
+        "require_client_certs": true,
+        "trust_file": "/etc/proxy/tls/sidecar/ca.crt",
+        "cert_key_pairs": [
+          {
+            "certificate_path": "/etc/proxy/tls/sidecar/server.crt",
+            "key_path": "/etc/proxy/tls/sidecar/server.key"
+          }
+        ]
+      },
+    "force_https": true
+}

--- a/catalog-egress-mesh-objects/listeners/egress.json
+++ b/catalog-egress-mesh-objects/listeners/egress.json
@@ -1,0 +1,12 @@
+{
+    "zone_key": "zone-default-zone",
+    "listener_key": "listener-catalog-egress",
+    "domain_keys": [
+        "domain-catalog-egress"
+    ],
+    "name": "egress",
+    "ip": "0.0.0.0",
+    "port": 10909,
+    "protocol": "http_auto",
+    "tracing_config": null
+}

--- a/catalog-egress-mesh-objects/listeners/ingress.json
+++ b/catalog-egress-mesh-objects/listeners/ingress.json
@@ -1,0 +1,25 @@
+{
+    "zone_key": "zone-default-zone",
+    "listener_key": "listener-catalog-ingress",
+    "domain_keys": [
+        "domain-catalog-ingress"
+    ],
+    "name": "ingress",
+    "ip": "0.0.0.0",
+    "port": 10808,
+    "protocol": "http_auto",
+    "tracing_config": null,
+    "active_http_filters": ["gm.metrics"],
+    "http_filters": {
+        "gm_metrics": {
+            "metrics_port": 8081,
+            "metrics_host": "0.0.0.0",
+            "metrics_dashboard_uri_path": "/metrics",
+            "metrics_prometheus_uri_path": "/prometheus",
+            "metrics_ring_buffer_size": 4096,
+            "prometheus_system_metrics_interval_seconds": 15,
+            "metrics_key_function": "depth",
+            "metrics_key_depth": "3"
+          }
+    }
+}

--- a/catalog-egress-mesh-objects/proxies/proxy.json
+++ b/catalog-egress-mesh-objects/proxies/proxy.json
@@ -1,0 +1,14 @@
+{
+    "zone_key": "zone-default-zone",
+    "proxy_key": "catalog-proxy",
+    "domain_keys": [
+        "domain-catalog-ingress",
+        "domain-catalog-egress"
+    ],
+    "listener_keys": [
+        "listener-catalog-ingress",
+        "listener-catalog-egress"
+    ],
+    "name": "catalog",
+    "listeners": null
+}

--- a/catalog-egress-mesh-objects/remove.sh
+++ b/catalog-egress-mesh-objects/remove.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+for cl in clusters/*.json
+do
+    key=$(jq .cluster_key $cl)
+    key="${key%\"}"
+    key="${key#\"}"
+    greymatter delete cluster $key
+done
+for cl in domains/*.json
+do
+    key=$(jq .domain_key $cl)
+    key="${key%\"}"
+    key="${key#\"}"
+    greymatter delete domain $key
+done
+for cl in listeners/*.json
+do
+    key=$(jq .listener_key $cl)
+    key="${key%\"}"
+    key="${key#\"}"
+    greymatter delete listener $key
+done
+for cl in proxies/*.json
+do
+    key=$(jq .proxy_key $cl)
+    key="${key%\"}"
+    key="${key#\"}"
+    greymatter delete proxy $key
+done
+for cl in rules/*.json
+do
+    key=$(jq .shared_rules_key $cl)
+    key="${key%\"}"
+    key="${key#\"}"
+    greymatter delete shared_rules $key
+done
+for cl in routes/*.json
+do
+    key=$(jq .route_key $cl)
+    key="${key%\"}"
+    key="${key#\"}"
+    greymatter delete route $key
+done
+
+curl -k -XDELETE --cert $GREYMATTER_API_SSLCERT --key $GREYMATTER_API_SSLKEY https://$GREYMATTER_API_HOST/services/catalog/latest/clusters/catalog?zoneName=zone-default-zone

--- a/catalog-egress-mesh-objects/routes/edge-slash.json
+++ b/catalog-egress-mesh-objects/routes/edge-slash.json
@@ -1,0 +1,13 @@
+{
+    "zone_key": "zone-default-zone",
+    "domain_key": "edge",
+    "route_key": "edge-catalog-route-slash",
+    "path": "/services/catalog/latest",
+    "prefix_rewrite": "/services/catalog/latest/",
+    "redirects": null,
+    "shared_rules_key": "edge-catalog-shared-rules",
+    "rules": null,
+    "response_data": {},
+    "cohort_seed": null,
+    "retry_policy": null
+}

--- a/catalog-egress-mesh-objects/routes/edge.json
+++ b/catalog-egress-mesh-objects/routes/edge.json
@@ -1,0 +1,13 @@
+{
+    "zone_key": "zone-default-zone",
+    "domain_key": "edge",
+    "route_key": "edge-catalog-route",
+    "path": "/services/catalog/latest/",
+    "prefix_rewrite": "/",
+    "redirects": null,
+    "shared_rules_key": "edge-catalog-shared-rules",
+    "rules": null,
+    "response_data": {},
+    "cohort_seed": null,
+    "retry_policy": null
+}

--- a/catalog-egress-mesh-objects/routes/egress-route.json
+++ b/catalog-egress-mesh-objects/routes/egress-route.json
@@ -1,0 +1,9 @@
+{
+    "zone_key": "zone-default-zone",
+    "domain_key": "domain-catalog-egress",
+    "route_key": "route-catalog-control-egress",
+    "path": "/control/",
+    "timeout": "0s",
+    "prefix_rewrite": "/",
+    "shared_rules_key": "catalog-control-rules"
+  }

--- a/catalog-egress-mesh-objects/routes/local.json
+++ b/catalog-egress-mesh-objects/routes/local.json
@@ -1,0 +1,13 @@
+{
+    "zone_key": "zone-default-zone",
+    "domain_key": "domain-catalog-ingress",
+    "route_key": "route-catalog-local",
+    "path": "/",
+    "prefix_rewrite": "",
+    "redirects": null,
+    "shared_rules_key": "rules-catalog-local",
+    "rules": null,
+    "response_data": {},
+    "cohort_seed": null,
+    "retry_policy": null
+}

--- a/catalog-egress-mesh-objects/rules/edge.json
+++ b/catalog-egress-mesh-objects/rules/edge.json
@@ -1,0 +1,24 @@
+{
+    "zone_key": "zone-default-zone",
+    "shared_rules_key": "edge-catalog-shared-rules",
+    "name": "catalog",
+    "default": {
+        "light": [
+            {
+                "constraint_key": "",
+                "cluster_key": "edge-to-catalog-cluster",
+                "metadata": null,
+                "properties": null,
+                "response_data": {},
+                "weight": 1
+            }
+        ],
+        "dark": null,
+        "tap": null
+    },
+    "rules": null,
+    "response_data": {},
+    "cohort_seed": null,
+    "properties": null,
+    "retry_policy": null
+}

--- a/catalog-egress-mesh-objects/rules/egress-rules.json
+++ b/catalog-egress-mesh-objects/rules/egress-rules.json
@@ -1,0 +1,19 @@
+{
+    "zone_key": "zone-default-zone",
+    "shared_rules_key": "catalog-control-rules",
+    "name": "catalog-control",
+    "default": {
+      "light": [
+        {
+          "constraint_key": "",
+          "cluster_key": "catalog-control-cluster",
+          "metadata": null,
+          "properties": null,
+          "response_data": {},
+          "weight": 1
+        }
+      ],
+      "dark": null,
+      "tap": null
+    }
+  }

--- a/catalog-egress-mesh-objects/rules/local.json
+++ b/catalog-egress-mesh-objects/rules/local.json
@@ -1,0 +1,24 @@
+{
+    "zone_key": "zone-default-zone",
+    "shared_rules_key": "rules-catalog-local",
+    "name": "catalog-local",
+    "default": {
+        "light": [
+            {
+                "constraint_key": "",
+                "cluster_key": "cluster-catalog-local",
+                "metadata": null,
+                "properties": null,
+                "response_data": {},
+                "weight": 1
+            }
+        ],
+        "dark": null,
+        "tap": null
+    },
+    "rules": null,
+    "response_data": {},
+    "cohort_seed": null,
+    "properties": null,
+    "retry_policy": null
+}

--- a/edge/values.yaml
+++ b/edge/values.yaml
@@ -60,6 +60,18 @@ edge:
     xds_node_id:
       type: 'value'
       value: 'default'
+    xds_server_ca_path:
+      type: 'value'
+      value: /etc/proxy/tls/sidecar/ca.crt
+    xds_server_cert_path:
+      type: 'value'
+      value: /etc/proxy/tls/sidecar/server.crt    
+    xds_server_key_path:
+      type: 'value'
+      value: /etc/proxy/tls/sidecar/server.key
+    xds_enable_tls:
+      type: 'value'
+      value: 'true'
     envoy_admin_log_path:
       type: 'value'
       value: '/dev/stdout'

--- a/fabric/control-api/json/services/cluster.json
+++ b/fabric/control-api/json/services/cluster.json
@@ -2,6 +2,7 @@
   "cluster_key": "cluster-{{.service.serviceName}}",
   "zone_key": "{{ .Values.global.zone}}",
   "name": "{{.service.serviceName}}-service",
+  "http2_protocol_options": {},
   "instances": [
     {
         "host": "127.0.0.1",

--- a/fabric/control-api/json/services/cluster.json
+++ b/fabric/control-api/json/services/cluster.json
@@ -2,7 +2,9 @@
   "cluster_key": "cluster-{{.service.serviceName}}",
   "zone_key": "{{ .Values.global.zone}}",
   "name": "{{.service.serviceName}}-service",
+  {{- if ( eq .service.serviceName "control") }}
   "http2_protocol_options": {},
+  {{- end }}
   "instances": [
     {
         "host": "127.0.0.1",

--- a/fabric/control-api/json/services/cluster.json
+++ b/fabric/control-api/json/services/cluster.json
@@ -3,7 +3,9 @@
   "zone_key": "{{ .Values.global.zone}}",
   "name": "{{.service.serviceName}}-service",
   {{- if ( eq .service.serviceName "control") }}
-  "http2_protocol_options": {},
+  "http2_protocol_options": {
+    "allow_connect": true
+  },
   {{- end }}
   "instances": [
     {

--- a/fabric/control-api/json/services/route.json
+++ b/fabric/control-api/json/services/route.json
@@ -1,3 +1,19 @@
+{{- if ( eq .service.serviceName "control") }}
+{
+  "route_key": "route-{{.service.serviceName}}",
+  "domain_key": "domain-{{.service.serviceName}}",
+  "zone_key": "{{ .Values.global.zone}}",
+  "path": "/",
+  "prefix_rewrite": null,
+  "redirects": null,
+  "shared_rules_key": "shared-rules-{{ .service.serviceName }}",
+  "rules": null,
+  "timeout": "0s",
+  "response_data": {},
+  "cohort_seed": null,
+  "retry_policy": null
+}
+{{- else}}
 {
   "route_key": "route-{{.service.serviceName}}",
   "domain_key": "domain-{{.service.serviceName}}",
@@ -11,3 +27,4 @@
   "cohort_seed": null,
   "retry_policy": null
 }
+{{- end}}

--- a/fabric/control-api/templates/_envvars.tpl
+++ b/fabric/control-api/templates/_envvars.tpl
@@ -42,9 +42,24 @@ We use indentation in the template for readability, but the template returns the
 Most users should use the `indent` or `nindent` functions to automatically indent the proper amount. */}}
 {{- define "sidecar.envvars" }}
   {{- $top := . }}
+  {{- if and .Values.global.sidecar.envvars $top.Values.sidecar.envvars }}
+    {{- $allvars := merge $top.Values.sidecar.envvars .Values.global.sidecar.envvars }}
+    {{- range $name, $envvar := $allvars }}
+      {{- $envName := $name | upper | replace "." "_" | replace "-" "_" }}
+      {{- $args := dict "name" $envName "value" $envvar "top" $top }}
+      {{- include "envvar" $args }}
+    {{- end }}
+  {{- else if .Values.global.sidecar.envvars }}
+    {{- range $name, $envvar := .Values.global.sidecar.envvars }}
+      {{- $envName := $name | upper | replace "." "_" | replace "-" "_" }}
+      {{- $args := dict "name" $envName "value" $envvar "top" $top }}
+      {{- include "envvar" $args }}
+    {{- end }}
+  {{- else if $top.Values.sidecar.envvars }}
     {{- range $name, $envvar := $top.Values.sidecar.envvars }}
       {{- $envName := $name | upper | replace "." "_" | replace "-" "_" }}
       {{- $args := dict "name" $envName "value" $envvar "top" $top }}
       {{- include "envvar" $args }}
     {{- end }}
-{{- end }} 
+  {{- end }}
+{{- end }}

--- a/fabric/control-api/templates/_envvars.tpl
+++ b/fabric/control-api/templates/_envvars.tpl
@@ -42,24 +42,9 @@ We use indentation in the template for readability, but the template returns the
 Most users should use the `indent` or `nindent` functions to automatically indent the proper amount. */}}
 {{- define "sidecar.envvars" }}
   {{- $top := . }}
-  {{- if and .Values.global.sidecar.envvars $top.Values.sidecar.envvars }}
-    {{- $allvars := merge $top.Values.sidecar.envvars .Values.global.sidecar.envvars }}
-    {{- range $name, $envvar := $allvars }}
-      {{- $envName := $name | upper | replace "." "_" | replace "-" "_" }}
-      {{- $args := dict "name" $envName "value" $envvar "top" $top }}
-      {{- include "envvar" $args }}
-    {{- end }}
-  {{- else if .Values.global.sidecar.envvars }}
-    {{- range $name, $envvar := .Values.global.sidecar.envvars }}
-      {{- $envName := $name | upper | replace "." "_" | replace "-" "_" }}
-      {{- $args := dict "name" $envName "value" $envvar "top" $top }}
-      {{- include "envvar" $args }}
-    {{- end }}
-  {{- else if $top.Values.sidecar.envvars }}
     {{- range $name, $envvar := $top.Values.sidecar.envvars }}
       {{- $envName := $name | upper | replace "." "_" | replace "-" "_" }}
       {{- $args := dict "name" $envName "value" $envvar "top" $top }}
       {{- include "envvar" $args }}
     {{- end }}
-  {{- end }}
-{{- end }}
+{{- end }} 

--- a/fabric/control-api/values.yaml
+++ b/fabric/control-api/values.yaml
@@ -180,9 +180,6 @@ sidecar:
     xds_cluster:
       type: value
       value: 'control-api'
-    proxy_dynamic:
-      type: 'value'
-      value: 'true'
     xds_zone:
       type: 'value'
       value: '{{ .Values.global.zone }}'
@@ -192,12 +189,12 @@ sidecar:
     xds_port:
       type: 'value'
       value: '50000'
+    xds_node_id:
       type: 'value'
       value: 'default'
     envoy_admin_log_path:
       type: 'value'
       value: '/dev/stdout'
-
 
 bootstrap:
   version: 2.0.0

--- a/fabric/control-api/values.yaml
+++ b/fabric/control-api/values.yaml
@@ -176,6 +176,27 @@ sidecar:
     requests:
       cpu: 100m
       memory: 128Mi
+  envvars:
+    xds_cluster:
+      type: value
+      value: 'control-api'
+    proxy_dynamic:
+      type: 'value'
+      value: 'true'
+    xds_zone:
+      type: 'value'
+      value: '{{ .Values.global.zone }}'
+    xds_host:
+      type: 'value'
+      value: 'control.{{ .Release.Namespace }}.svc'
+    xds_port:
+      type: 'value'
+      value: '50000'
+      type: 'value'
+      value: 'default'
+    envoy_admin_log_path:
+      type: 'value'
+      value: '/dev/stdout'
 
 
 bootstrap:
@@ -344,6 +365,28 @@ services:
     description: The Grey Matter JWT security service is a JWT Token generation and retrieval service.
     # External links configures the "Service Tools" dropdown in service view
     externalLinks: []
+    secret:
+      enabled: true
+      secret_name: sidecar-certs
+      mount_point: /etc/proxy/tls/sidecar
+      insecure: true
+      secret_keys:
+        cert: server.crt
+        key: server.key
+        ca: ca.crt
+
+  control:
+    catalogEnabled: true
+    controlEnabled: true
+    name: 'Grey Matter Control'
+    serviceName: 'control'
+    observablesEnabled: false
+    port: 50000
+    enableInstanceMetrics: 'true'
+    capability: 'Mesh'
+    documentation:
+    owner: 'Decipher'
+    version: '1.4.3'
     secret:
       enabled: true
       secret_name: sidecar-certs

--- a/fabric/control/templates/_envvars.tpl
+++ b/fabric/control/templates/_envvars.tpl
@@ -15,3 +15,33 @@
       {{- end }}
   {{- end }}
 {{- end }}
+
+{{/* envvar take a dictionary of name, value, and top as arguments, and generates a single environment variable from it. */}}
+{{/* Top must be the scope of the top of a named template or any scope which includes the default values, namely .Template (since we use the `tpl` function in this template, .Template.BasePath is required for some reason) */}}
+{{- define "envvar" }}
+    {{- $envName := index . "name" }}
+    {{- $e := index . "value" }}
+    {{- $top := index . "top" }}
+        {{- if eq $e.type "secret" }}
+- name: {{ $envName }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $e.secret }}
+      key: {{ $e.key }}
+        {{- else if eq $e.type "value" }}
+- name: {{ $envName }}
+  value: {{ tpl $e.value $top | quote }} 
+        {{- end }}
+{{- end }}
+
+{{- /*  envvars loops through the global sidecar envvars and generates Kubernetes container env keys for both regular values and secrets from the local sidecar values and from the global values as a backup.
+We use indentation in the template for readability, but the template returns the output without indents, leaving it up to the user
+Most users should use the `indent` or `nindent` functions to automatically indent the proper amount. */}}
+{{- define "sidecar.envvars" }}
+  {{- $top := . }}
+    {{- range $name, $envvar := $top.Values.sidecar.envvars }}
+      {{- $envName := $name | upper | replace "." "_" | replace "-" "_" }}
+      {{- $args := dict "name" $envName "value" $envvar "top" $top }}
+      {{- include "envvar" $args }}
+    {{- end }}
+{{- end }} 

--- a/fabric/control/templates/_envvars.tpl
+++ b/fabric/control/templates/_envvars.tpl
@@ -39,9 +39,24 @@ We use indentation in the template for readability, but the template returns the
 Most users should use the `indent` or `nindent` functions to automatically indent the proper amount. */}}
 {{- define "sidecar.envvars" }}
   {{- $top := . }}
+  {{- if and .Values.global.sidecar.envvars $top.Values.sidecar.envvars }}
+    {{- $allvars := merge $top.Values.sidecar.envvars .Values.global.sidecar.envvars }}
+    {{- range $name, $envvar := $allvars }}
+      {{- $envName := $name | upper | replace "." "_" | replace "-" "_" }}
+      {{- $args := dict "name" $envName "value" $envvar "top" $top }}
+      {{- include "envvar" $args }}
+    {{- end }}
+  {{- else if .Values.global.sidecar.envvars }}
+    {{- range $name, $envvar := .Values.global.sidecar.envvars }}
+      {{- $envName := $name | upper | replace "." "_" | replace "-" "_" }}
+      {{- $args := dict "name" $envName "value" $envvar "top" $top }}
+      {{- include "envvar" $args }}
+    {{- end }}
+  {{- else if $top.Values.sidecar.envvars }}
     {{- range $name, $envvar := $top.Values.sidecar.envvars }}
       {{- $envName := $name | upper | replace "." "_" | replace "-" "_" }}
       {{- $args := dict "name" $envName "value" $envvar "top" $top }}
       {{- include "envvar" $args }}
     {{- end }}
-{{- end }} 
+  {{- end }}
+{{- end }}

--- a/fabric/control/templates/control-service.yaml
+++ b/fabric/control/templates/control-service.yaml
@@ -11,7 +11,7 @@ spec:
   - name: control-sidecar
     port: {{ .Values.global.control.port }}
     protocol: TCP
-    targetPort: grpc
+    targetPort: proxy
   - name: control
     port: 50000
     protocol: TCP

--- a/fabric/control/templates/control-service.yaml
+++ b/fabric/control/templates/control-service.yaml
@@ -8,9 +8,14 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
-  - port: {{ .Values.global.control.port }}
+  - name: control-sidecar
+    port: {{ .Values.global.control.port }}
     protocol: TCP
     targetPort: grpc
+  - name: control
+    port: 50000
+    protocol: TCP
+    targetPort: 50000
   selector:
     run: {{ .Values.control.name }}
   type: ClusterIP

--- a/fabric/control/templates/control.yaml
+++ b/fabric/control/templates/control.yaml
@@ -40,6 +40,36 @@ spec:
             - name: controlapi-certs
               mountPath: {{ .Values.control.secret.mount_point }}
         {{- end }}
+        - name: sidecar
+          image: '{{ tpl .Values.sidecar.image $ }}'
+          imagePullPolicy: {{ .Values.sidecar.image_pull_policy }}
+          {{- if .Values.sidecar.resources }}
+          resources:
+  {{ toYaml .Values.sidecar.resources | indent 10 }}
+          {{- end }}
+          ports:
+          - name: proxy
+            containerPort: {{ .Values.sidecar.port }}
+          - name: metrics
+            containerPort: {{ .Values.sidecar.metrics_port }}
+          env:
+          {{- include "sidecar.envvars" . | indent 12 }}
+          {{- if .Values.global.spire.enabled }}
+          - name: SPIRE_PATH
+            value: {{ .Values.global.spire.path }}
+          {{- end }}
+          volumeMounts:
+          {{- if .Values.global.spire.enabled }}
+          {{- include "spire_volume_mount" . | indent 8 }}
+          {{- else if .Values.sidecar.secret.enabled }}
+          - name: sidecar-certs
+            mountPath: {{ .Values.sidecar.secret.mount_point }}
+            readOnly: true
+          {{- end }}
+        {{- if .Values.global.consul.enabled }}
+        {{- $data := dict "Values" .Values "ServiceName" "dashboard" }}
+        {{- include "consul.agent" $data | nindent 6 }}
+        {{- end }}
       initContainers:
         - name: ensure-control-api
           image: {{ .Values.global.waiter.image }}
@@ -61,4 +91,9 @@ spec:
             {{- else }}
             secretName: {{ .Values.control.secret.secret_name }}
             {{- end }}
+        {{- if .Values.sidecar.secret.enabled }}
+        - name: sidecar-certs
+          secret:
+            secretName: {{ .Values.sidecar.secret.secret_name }}
+        {{- end }}
       {{- end }}

--- a/fabric/control/templates/control.yaml
+++ b/fabric/control/templates/control.yaml
@@ -34,7 +34,7 @@ spec:
               port: grpc
             initialDelaySeconds: 2
           resources:
-            {{- toYaml .Values.control.resources | nindent 12 }}
+{{ toYaml .Values.control.resources | indent 12 }}
         {{- if .Values.control.secret }}
           volumeMounts:
             - name: controlapi-certs
@@ -45,7 +45,7 @@ spec:
           imagePullPolicy: {{ .Values.sidecar.image_pull_policy }}
           {{- if .Values.sidecar.resources }}
           resources:
-  {{ toYaml .Values.sidecar.resources | indent 10 }}
+{{ toYaml .Values.sidecar.resources | indent 12 }}
           {{- end }}
           ports:
           - name: proxy

--- a/fabric/control/templates/control.yaml
+++ b/fabric/control/templates/control.yaml
@@ -29,10 +29,10 @@ spec:
             - name: grpc
               containerPort: {{ .Values.global.control.port }}
               protocol: TCP
-          livenessProbe:
-            tcpSocket:
-              port: grpc
-            initialDelaySeconds: 2
+          # livenessProbe:
+          #   tcpSocket:
+          #     port: grpc
+          #   initialDelaySeconds: 2
           resources:
 {{ toYaml .Values.control.resources | indent 12 }}
         {{- if .Values.control.secret }}

--- a/fabric/control/templates/control.yaml
+++ b/fabric/control/templates/control.yaml
@@ -27,7 +27,7 @@ spec:
             {{- include "envvars" (dict "envvar" .Values.control.envvars "top" $) | indent 10 }}
           ports:
             - name: grpc
-              containerPort: {{ .Values.global.control.port }}
+              containerPort: 50000
               protocol: TCP
           # livenessProbe:
           #   tcpSocket:

--- a/fabric/control/values.yaml
+++ b/fabric/control/values.yaml
@@ -108,7 +108,7 @@ control:
     gm_control_file_filename:
       type: 'null'
       value: '/app/routes.yaml'
-  resources: {}
+  resources:
 
 
 # Sidecar configuration for Control

--- a/fabric/control/values.yaml
+++ b/fabric/control/values.yaml
@@ -108,6 +108,21 @@ control:
     gm_control_file_filename:
       type: 'null'
       value: '/app/routes.yaml'
+    gm_control_xds_server_cert:
+      type: "value"
+      value: "/service-certs/server.crt"
+    gm_control_xds_server_key:
+      type: "value"
+      value: "/service-certs/server.key"
+    gm_control_xds_server_trusts:
+      type: "value"
+      value: "/service-certs/ca.crt"
+    gm_control_xds_enable_tls:
+      type: "value"
+      value: "true"
+    gm_control_xds_server_auth_type:
+      type: "value"
+      value: "noclientcert"
   resources:
 
 
@@ -149,7 +164,7 @@ sidecar:
       value: 'control.{{ .Release.Namespace }}.svc'
     xds_port:
       type: 'value'
-      value: '{{ .Values.global.control.port }}'
+      value: '50000'
     xds_node_id:
       type: 'value'
       value: 'default'

--- a/fabric/control/values.yaml
+++ b/fabric/control/values.yaml
@@ -109,3 +109,53 @@ control:
       type: 'null'
       value: '/app/routes.yaml'
   resources: {}
+
+
+# Sidecar configuration for Control
+sidecar:
+  version: '{{- $.Values.global.sidecar.version | default "latest" }}'
+  image: 'docker.greymatter.io/development/gm-proxy:{{ tpl $.Values.sidecar.version $ }}'
+  # Port where the proxy will listen
+  port: 10808
+  # Port where the proxy will expose metrics
+  metrics_port: 8081
+  secret:
+    enabled: true
+    secret_name: sidecar-certs
+    mount_point: /etc/proxy/tls/sidecar
+    secret_keys:
+      ca: ca.crt
+      cert: server.crt
+      key: server.key
+  # When to pull images, used in the deployment
+  image_pull_policy: IfNotPresent
+  # CPU and memory limits for the sidecar
+  resources:
+    limits:
+      cpu: 200m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  envvars:
+    xds_cluster:
+      type: value
+      value: 'control'
+    proxy_dynamic:
+      type: 'value'
+      value: 'true'
+    xds_zone:
+      type: 'value'
+      value: '{{ .Values.global.zone }}'
+    xds_host:
+      type: 'value'
+      value: 'control.{{ .Release.Namespace }}.svc'
+    xds_port:
+      type: 'value'
+      value: '{{ .Values.global.control.port }}'
+    xds_node_id:
+      type: 'value'
+      value: 'default'
+    envoy_admin_log_path:
+      type: 'value'
+      value: '/dev/stdout'

--- a/fabric/control/values.yaml
+++ b/fabric/control/values.yaml
@@ -141,9 +141,6 @@ sidecar:
     xds_cluster:
       type: value
       value: 'control'
-    proxy_dynamic:
-      type: 'value'
-      value: 'true'
     xds_zone:
       type: 'value'
       value: '{{ .Values.global.zone }}'

--- a/fabric/values.yaml
+++ b/fabric/values.yaml
@@ -63,6 +63,18 @@ global:
       envoy_admin_log_path:
         type: 'value'
         value: '/dev/stdout'
+      xds_server_ca_path:
+        type: 'value'
+        value: /etc/proxy/tls/sidecar/ca.crt
+      xds_server_cert_path:
+        type: 'value'
+        value: /etc/proxy/tls/sidecar/server.crt    
+      xds_server_key_path:
+        type: 'value'
+        value: /etc/proxy/tls/sidecar/server.key
+      xds_enable_tls:
+        type: 'value'
+        value: 'true'
 
 control:
   control:

--- a/fabric/values.yaml
+++ b/fabric/values.yaml
@@ -37,7 +37,7 @@ global:
     service_account:
       create: true
       name: waiter-sa
-  # Sidecar configuration (Control-api is the only service in this chart with a proxy)
+  # Sidecar configuration
   sidecar:
     # GM Proxy version, used by control-api
     version: 1.5.1

--- a/fabric/values.yaml
+++ b/fabric/values.yaml
@@ -529,6 +529,18 @@ jwt:
       xds_cluster:
         type: value
         value: 'jwt-security'
+      xds_zone:
+        type: 'value'
+        value: '{{ .Values.global.zone }}'
+      xds_host:
+        type: 'value'
+        value: 'control.{{ .Release.Namespace }}.svc'
+      xds_port:
+        type: 'value'
+        value: '{{ .Values.global.control.port }}'
+      xds_node_id:
+        type: 'value'
+        value: 'default'
 
   jwt:
     # Name used for the deployment and service resources

--- a/global.yaml
+++ b/global.yaml
@@ -15,7 +15,7 @@ global:
     edge_port: 10808
   control:
     # Port for Grey Matter Control. Used in sidecar envvars
-    port: 50000
+    port: 10808
     # The label Control uses to find pods to include in the mesh
     cluster_label: greymatter.io/control
     # Comma delimited string of namespaces for control to monitor. Also used by prometheus.
@@ -47,7 +47,7 @@ global:
 
   # Whether or not to use spire for cert management and the trust domain
   spire:
-    enabled: true
+    enabled: false
     trust_domain: quickstart.greymatter.io
     path: '/run/spire/socket/agent.sock'
   # Configures the init container used to wait on various deployments to be ready

--- a/sense/values.yaml
+++ b/sense/values.yaml
@@ -57,6 +57,18 @@ global:
       envoy_admin_log_path:
         type: 'value'
         value: '/dev/stdout'
+      xds_server_ca_path:
+        type: 'value'
+        value: /etc/proxy/tls/sidecar/ca.crt
+      xds_server_cert_path:
+        type: 'value'
+        value: /etc/proxy/tls/sidecar/server.crt    
+      xds_server_key_path:
+        type: 'value'
+        value: /etc/proxy/tls/sidecar/server.key
+      xds_enable_tls:
+        type: 'value'
+        value: 'true'
 slo:
   slo:
     # SLO version


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

This PR follows from https://github.com/greymatter-io/helm-charts/pull/785, but is updated with release-2.4 commits and is set to merge back into into release-2.4 instead of release-2.3.
Closes #749 
<br/><br/>

2. What **changes to custom.yaml** are required?
None.
<br/><br/>

3. Have you documented any additional setup steps or configurations options?
None.
<br/><br/>

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

- Spin up a kubernetes cluster with AWS (connect to the vpn): http://docs.greymatter.services/runbooks/kops-cluster/
- Checkout out this branch: `git checkout 749-sidecar-on-control
- Generate credentials (if they do not exist): `make credentials`
- Apply secrets: `make secrets`
- In `edge/values.yaml` change `ingress.type` to `LoadBalancer`
- Install Grey Matter: `make install`
- Run: `kubectl patch svc edge -p '{"metadata":{"annotations":{"service.beta.kubernetes.io/aws-load-balancer-internal":"true"}}}'`
- Run: `kubectl get svc` -- Copy the external IP on the edge service.
- Navigate to `https://{external-ip}:10808`

It may take a while for the url to resolve.
<br/><br/>
