### PR TITLE
fix fabric warning 2.3

### DIFF
--- a/fabric/Chart.yaml
+++ b/fabric/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.3.0
 description: A Helm chart to deploy Grey Matter Fabric
 name: fabric
-version: 3.0.6
+version: 3.0.7
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
@@ -15,7 +15,7 @@ keywords:
 dependencies:
   - name: control-api
     repository: file://./control-api
-    version: '3.0.12'
+    version: '3.0.13'
 
   - name: control
     repository: file://./control

--- a/fabric/control-api/Chart.yaml
+++ b/fabric/control-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.5.4
 description: Deploys the Grey Matter 2.0 control-api mesh-wide configuration API
 name: control-api
-version: 3.0.12
+version: 3.0.13
 home: https://greymatter.io
 maintainers:
   - name: greymatter-io

--- a/fabric/control-api/values.yaml
+++ b/fabric/control-api/values.yaml
@@ -149,7 +149,17 @@ controlApi:
     gm_control_api_base_url:
       type: value
       value: '/services/control-api/latest/v1.0/'
-  resources:
+  resources: 
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, and adjust them as necessary.
+    limits:
+      cpu: 500m
+      memory: 1Gi
+    requests:
+      cpu: 250m
+      memory: 256Mi
   pvc:
     size: 1Gi
 

--- a/fabric/control-api/values.yaml
+++ b/fabric/control-api/values.yaml
@@ -149,11 +149,11 @@ controlApi:
     gm_control_api_base_url:
       type: value
       value: '/services/control-api/latest/v1.0/'
-  resources: 
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, and adjust them as necessary.
+  resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, and adjust them as necessary.
     limits:
       cpu: 500m
       memory: 1Gi


### PR DESCRIPTION
…otations is a table. Ignoring non-table value' warning

**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

fixes issue which chart that caused this warning to apear: 'destination for annotations is a table. Ignoring non-table value'

2. What **changes to custom.yaml** are required?

none

3. Have you documented any additional setup steps or configurations options?

none

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

run : `helm template fabric -f global.yaml > f-temp.yaml`  you will not see the warning any more.

Tested in k3d
