### PR TITLE
Update all makefiles to produce '-dev' helm releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ dev-dep: clean
 
 .PHONY: check-secrets
 check-secrets:
-	$(eval SECRET_CHECK=$(shell helm ls | grep secrets | awk '{if ($$1 == "secrets") print "present"; else print "not-present"}'))
+	$(eval SECRET_CHECK=$(shell helm ls | grep secrets | awk '{if ($$1 ~ /secrets*/) print "present"; else print "not-present"}'))
 	if [[ "$(SECRET_CHECK)" != "present" ]]; then \
 		(make secrets); \
 	fi

--- a/edge/Makefile
+++ b/edge/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 current_dir := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
-NAME-EDGE := edge
+NAME-EDGE := edge-dev
 
 pwd_name := $(notdir $(PWD))
 
@@ -27,7 +27,7 @@ clean-edge:
 
 .PHONY: remove-edge
 remove-edge:
-	helm uninstall edge
+	helm uninstall $(NAME-EDGE)
 	
 template-edge: $(BUILD_NUMBER_FILE)
 	mkdir -p $(OUTPUT_PATH)

--- a/fabric/Makefile
+++ b/fabric/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-NAME-FABRIC:=fabric
+NAME-FABRIC:=fabric-dev
 CHART-FABRIC := .
 
 include ../output.mk

--- a/secrets/Makefile
+++ b/secrets/Makefile
@@ -1,4 +1,5 @@
 SHELL := /bin/bash
+NAME-SECRET:=secrets-dev
 
 include ../output.mk
 
@@ -15,21 +16,21 @@ copy-credentials:
 
 template-secrets: $(BUILD_NUMBER_FILE)
 	mkdir -p $(OUTPUT_PATH)
-	helm template secrets . --set=global.environment=kubernetes   -f ../credentials.yaml -f ../global.yaml > $(OUTPUT_PATH)/helm-secrets$(BN).yaml
+	helm template $(NAME-SECRET) . --set=global.environment=kubernetes   -f ../credentials.yaml -f ../global.yaml > $(OUTPUT_PATH)/helm-secrets$(BN).yaml
 
 .PHONY: secrets
 secrets: copy-credentials values-validation
-	helm install secrets . -f credentials.yaml -f ../global.yaml
+	helm install $(NAME-SECRET) . -f credentials.yaml -f ../global.yaml
 	rm credentials.yaml
 
 .PHONY: upgrade-secrets
 upgrade-secrets: copy-credentials values-validation
-	helm upgrade secrets . -f credentials.yaml -f ../global.yaml --install 
+	helm upgrade $(NAME-SECRET) . -f credentials.yaml -f ../global.yaml --install 
 	rm credentials.yaml
 
 .PHONY: remove-secrets
 remove-secrets:
-	helm uninstall secrets
+	helm uninstall $(NAME-SECRET)
 
 
 values-validation:

--- a/sense/Makefile
+++ b/sense/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-NAME-SENSE:=sense
+NAME-SENSE:=sense-dev
 CHART-SENSE := .
 
 include ../output.mk


### PR DESCRIPTION
this pr will make it so when you run a `make install` it creates releases with `-dev` aka `fabric-dev` `secrets-dev` etc.

No updates to global.yaml or any other part of the charts.

To test run `make secrets` and `make install` once completed run `helm ls` and you get

```
NAME                    NAMESPACE       REVISION        UPDATED                                 STATUS          CHART           APP VERSION
edge-dev                default         1               2021-02-04 15:24:07.676001 -0500 EST    deployed        edge-3.0.2      1.5.1      
fabric-dev              default         1               2021-02-04 15:22:57.418526 -0500 EST    deployed        fabric-3.0.7    1.3.0      
secrets-dev             default         1               2021-02-04 14:55:58.466053 -0500 EST    deployed        secrets-2.3.0              
sense-dev               default         1               2021-02-04 15:24:55.814033 -0500 EST    deployed        sense-3.0.6     1.3.0      
spire-dev-agent         default         1               2021-02-04 15:22:50.805643 -0500 EST    deployed        agent-2.2.5     1.2.0      
spire-dev-server        default         1               2021-02-04 15:22:29.26523 -0500 EST     deployed        server-2.2.5    1.2.0  
```

and you will be able to hit the dashboard however you want.