### PR TITLE
Helm release names

### DIFF
--- a/.chart-testing/services.yaml
+++ b/.chart-testing/services.yaml
@@ -1,5 +1,4 @@
-chart-dirs:
-  - data
+charts:
   - fabric
   - sense
   - spire

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -137,7 +137,9 @@ jobs:
           echo "$KUBECONFIG"
 
       - name: Make secrets
-        run: make secrets
+        run: |
+          export KUBECONFIG=$(k3d kubeconfig write greymatter)
+          make secrets
 
       - name: Run tests
         run: |

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -123,6 +123,14 @@ jobs:
           cp ./ci/scripts/credentials.template ./credentials.yaml
           printf '%s\n' $NEXUS_USER $NEXUS_PASSWORD n | ./ci/scripts/build-credentials.sh
 
+      - name: Login to Greymatter docker
+        env:
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+        run: |-
+          # Log into docker.greymatter.io
+          docker login -u $NEXUS_USER -p $NEXUS_PASSWORD
+
       - name: Make secrets
         run: make secrets
 

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -129,7 +129,7 @@ jobs:
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
         run: |-
           # Log into docker.greymatter.io
-          docker login -u $NEXUS_USER -p $NEXUS_PASSWORD
+          docker login -u $NEXUS_USER -p $NEXUS_PASSWORD docker.greymatter.io
 
       - name: Make secrets
         run: make secrets

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -131,11 +131,6 @@ jobs:
           # Log into docker.greymatter.io
           docker login -u $NEXUS_USER -p $NEXUS_PASSWORD docker.greymatter.io
 
-      - name: Check k8s connections
-        run: |
-          kubectl get nodes
-          echo "$KUBECONFIG"
-
       - name: Make secrets
         run: |
           export KUBECONFIG=$(k3d kubeconfig write greymatter)

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -134,6 +134,7 @@ jobs:
       - name: Check k8s connections
         run: |
           kubectl get nodes
+          echo "$KUBECONFIG"
 
       - name: Make secrets
         run: make secrets

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -131,6 +131,10 @@ jobs:
           # Log into docker.greymatter.io
           docker login -u $NEXUS_USER -p $NEXUS_PASSWORD docker.greymatter.io
 
+      - name: Check k8s connections
+        run: |
+          kubectl get nodes
+
       - name: Make secrets
         run: make secrets
 

--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,8 @@ dev-dep: clean
 	(cd sense && make package-sense)
 
 check-secrets:
-	$(eval SECRET_CHECK=$(shell helm ls | grep secrets | awk '{if ($$1 ~ /secrets*/) print "present"; else print "not-present"}'))
-	if [[ "$(SECRET_CHECK)" != "present" ]]; then \
+	@$(eval SECRET_CHECK=$(shell helm ls | grep secrets | awk '{if ($$1 ~ /secrets*/) print "present"; else print "not-present"}'))
+	@if [[ "$(SECRET_CHECK)" != "present" ]]; then \
 		(make secrets); \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+include helpers.mk
 #  This simple makefile provides an easy shortcut for commonly used helm commands
 
 # `make credentials` to build out credentials with user input
@@ -13,7 +13,7 @@ minikube:
 
 k3d:
 	./ci/scripts/k3d.sh
-  K3D=true
+  	K3D=true
 
 reveal-endpoint:
 	./ci/scripts/show-voyager.sh
@@ -45,7 +45,7 @@ check-secrets:
 	fi
 
 install-spire:
-	$(eval IS=$(shell cat global.yaml | grep -A3 'spire:'| grep enabled: | awk '{print $$2}'))
+	$(eval IS=$(shell cat $(HOME)/global.yaml | grep -A3 'spire:'| grep enabled: | awk '{print $$2}'))
 	if [ "$(IS)" = "true" ]; then \
 		(cd spire && make spire); \
 	fi
@@ -60,10 +60,12 @@ install: dev-dep check-secrets install-spire
 	fi
 	sleep 20
 	(cd sense && make sense)
+	(make remove-identity)
 	(make reveal-endpoint)
 
+
 .IGNORE: uninstall
-uninstall:
+uninstall: verify-identity-exists
 	-(cd spire && make remove-spire)
 	-(cd fabric && make remove-fabric)
 	-(cd edge && make remove-edge)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 SHELL := /bin/bash
 #  This simple makefile provides an easy shortcut for commonly used helm commands
 
-include output.mk
 # `make credentials` to build out credentials with user input
 # `make secrets` deploys the credentials
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ reveal-endpoint:
 
 .IGNORE= destroy
 destroy:
-	-(make delete)
 	-minikube delete
 	-k3d cluster delete greymatter
 	-(eval unset KUBECONFIG)
@@ -42,7 +41,7 @@ dev-dep: clean
 
 .PHONY: check-secrets
 check-secrets:
-	$(eval SECRET_CHECK=$(shell helm ls | grep secrets | awk '{if ($$1 == "secrets") print "present"; else print "not-present"}'))
+	$(eval SECRET_CHECK=$(shell helm ls | grep secrets | awk '{if ($$1 ~ /secrets*/) print "present"; else print "not-present"}'))
 	if [[ "$(SECRET_CHECK)" != "present" ]]; then \
 		(make secrets); \
 	fi
@@ -126,3 +125,21 @@ remove-observables:
 .PHONY: spire-custom-ca
 spire-custom-ca:
 	cd spire && make custom-ca
+
+.PHONY: lint-subcharts
+lint-subcharts:
+	@echo "Lint Fabric, Sense, and Spire subcharts"
+	ct lint --config .chart-testing/services.yaml
+
+.PHONY: lint-edge-secrets
+lint-edge-secrets:
+	@echo "Lint Edge and Secrets"
+	ct lint --config .chart-testing/edge-secrets.yaml 
+
+.PHONY: lint-umberela-charts
+lint-umberela-charts:
+	@echo "Lint top level charts"
+	ct lint --target-branch release-2.3 --chart-dirs .
+
+.PHONY: lint
+lint: lint-subcharts lint-edge-secrets lint-umberela-charts

--- a/Makefile
+++ b/Makefile
@@ -135,10 +135,10 @@ lint-edge-secrets:
 	@echo "Lint Edge and Secrets"
 	ct lint --config .chart-testing/edge-secrets.yaml 
 
-.PHONY: lint-umberela-charts
-lint-umberela-charts:
+.PHONY: lint-umbrella-charts
+lint-umbrella-charts:
 	@echo "Lint top level charts"
 	ct lint --target-branch release-2.3 --chart-dirs .
 
 .PHONY: lint
-lint: lint-subcharts lint-edge-secrets lint-umberela-charts
+lint: lint-subcharts lint-edge-secrets lint-umbrella-charts

--- a/README.md
+++ b/README.md
@@ -42,6 +42,41 @@ helm install sense greymatter/sense -f global.yaml --set=global.waiter.service_a
 ```
 
 > If you would like to scale to a production ready mesh set global.release.production to true in `global.yaml`
+#### Mesh Identity
+
+A `greymatter-mesh-identity-<customer_name>` configmap is created and holds a randomly generated 6 digit alpha numeric code and customer name.  These are used by the makefiles to create the named releases.  Per the Makefiles these helm releases will be of the form `<chart>-<customer_name>-<random_string>`.  This provides developers an extra layer of security for the mesh since the makefile rules load information from the existing mesh.  If you want to prevent accidental deletion of the mesh then you can delete the mesh identity configmap.  This configmap can be recreated using the info in the helm releases but provides a two step process for release deletion when using makefiles.
+
+**Find the mesh instance configmap:**
+
+```console
+kubectl get configmap | grep mesh-identity
+```
+
+**Delete the mesh instance configmap:**
+
+```console
+kubectl delete configmap <name of configmap>
+```
+
+**Reinstate the mesh instance configmap:**
+
+Create the configmap yaml:
+
+Run `helm ls` and you will see releases of the form `<chart>-<customer_name>-<random_string>`.  Create a yaml from the template below and populate the `<customer_name>` and `<random_string>` accordingly.  Then run `kubectl apply -f <your file>`
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: greymatter-mesh-identity-<customer_name>
+  namespace: <namespace>
+spec:
+  customer: <customer_name>
+  rand_identifier: <random_string>
+```
+
+> Once the mesh instance configmap is reinstated you will again be able to run make commands against the releases.
+> **Note, this does not protect against a user running helm uninstall manually**
 
 ### Viewing the Grey Matter Application
 

--- a/README.md
+++ b/README.md
@@ -42,27 +42,22 @@ helm install sense greymatter/sense -f global.yaml --set=global.waiter.service_a
 ```
 
 > If you would like to scale to a production ready mesh set global.release.production to true in `global.yaml`
+
 #### Mesh Identity
 
-A `greymatter-mesh-identity-<customer_name>` configmap is created and holds a randomly generated 6 digit alpha numeric code and customer name.  These are used by the makefiles to create the named releases.  Per the Makefiles these helm releases will be of the form `<chart>-<customer_name>-<random_string>`.  This provides developers an extra layer of security for the mesh since the makefile rules load information from the existing mesh.  If you want to prevent accidental deletion of the mesh then you can delete the mesh identity configmap.  This configmap can be recreated using the info in the helm releases but provides a two step process for release deletion when using makefiles.
+A `greymatter-mesh-identity-<customer_name>` configmap is created and holds a randomly generated 6 digit alpha numeric code and customer name.  These are used by the makefiles to create the named releases.  Per the Makefiles these helm releases will be of the form `<chart>-<customer_name>-<random_string>`.  This provides developers an extra layer of security for the mesh since the makefile rules load information from the existing mesh. After installation of the service mesh is complete the configmap is deleted.
 
-**Find the mesh instance configmap:**
-
-```console
-kubectl get configmap | grep mesh-identity
-```
-
-**Delete the mesh instance configmap:**
+**To recreate the configmap using helm:**
 
 ```console
-kubectl delete configmap <name of configmap>
+make restore-identity
 ```
 
-**Reinstate the mesh instance configmap:**
+**Reinstate the configmap manually:**
 
 Create the configmap yaml:
 
-Run `helm ls` and you will see releases of the form `<chart>-<customer_name>-<random_string>`.  Create a yaml from the template below and populate the `<customer_name>` and `<random_string>` accordingly.  Then run `kubectl apply -f <your file>`
+Run `helm ls` and you will see releases of the form `<chart>-<customer_name>-<random_string>`.  Create a yaml from the template below and populate the `<customer_name>` and `<random_string>` accordingly.  Then run `kubectl apply -f <your file>`.
 
 ```yaml
 apiVersion: v1

--- a/data/Makefile
+++ b/data/Makefile
@@ -5,11 +5,11 @@ CHART_DATA := .
 include ../output.mk
 
 wsa-data:
-	$(eval WAITERSACHECK-DATA=$(shell kubectl get sa waiter-sa 2> /dev/null | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}'))
+	$(eval WSA_CHECK-DATA=$(shell kubectl get sa waiter-sa 2> /dev/null | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}'))
 
 .PHONY: gm-data
 gm-data: wsa-data
-	helm install $(NAME-DATA) gm-data $(WAITERSACHECK-DATA) -f ../global.yaml
+	helm install $(NAME-DATA) gm-data $(WSA_CHECK-DATA) -f ../global.yaml
 
 clean-data:
 	rm -f ./charts/*
@@ -19,15 +19,15 @@ package-data: clean-data
 
 template-data: package-data $(BUILD_NUMBER_FILE)
 	mkdir -p $(OUTPUT_PATH)
-	helm template $(NAME-DATA) . $(WAITERSACHECK-DATA)  -f ../global.yaml > $(OUTPUT_PATH)/helm-$(NAME-DATA)$(BN).yaml
+	helm template $(NAME-DATA) . $(WSA_CHECK-DATA)  -f ../global.yaml > $(OUTPUT_PATH)/helm-$(NAME-DATA)$(BN).yaml
 
 .PHONY: data
 data: package-data wsa-data
-	helm install $(NAME-DATA) . $(WAITERSACHECK-DATA) -f ../global.yaml
+	helm install $(NAME-DATA) . $(WSA_CHECK-DATA) -f ../global.yaml
 
 .PHONY: upgrade-data
 upgrade-data: wsa-data package-data
-	helm upgrade $(NAME-DATA) . $(WAITERSACHECK-DATA) -f ../global.yaml
+	helm upgrade $(NAME-DATA) . $(WSA_CHECK-DATA) -f ../global.yaml
 
 .PHONY: remove-data
 remove-data:

--- a/data/Makefile
+++ b/data/Makefile
@@ -5,11 +5,11 @@ CHART_DATA := .
 include ../output.mk
 
 wsa-data:
-	$(eval WSA_CHECK-DATA=$(shell kubectl get sa waiter-sa 2> /dev/null | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}'))
+	$(eval WAITERSACHECK-DATA=$(shell kubectl get sa waiter-sa 2> /dev/null | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}'))
 
 .PHONY: gm-data
 gm-data: wsa-data
-	helm install $(NAME-DATA) gm-data $(WSA_CHECK-DATA) -f ../global.yaml
+	helm install $(NAME-DATA) gm-data $(WAITERSACHECK-DATA) -f ../global.yaml
 
 clean-data:
 	rm -f ./charts/*
@@ -19,15 +19,15 @@ package-data: clean-data
 
 template-data: package-data $(BUILD_NUMBER_FILE)
 	mkdir -p $(OUTPUT_PATH)
-	helm template $(NAME-DATA) . $(WSA_CHECK-DATA)  -f ../global.yaml > $(OUTPUT_PATH)/helm-$(NAME-DATA)$(BN).yaml
+	helm template $(NAME-DATA) . $(WAITERSACHECK-DATA)  -f ../global.yaml > $(OUTPUT_PATH)/helm-$(NAME-DATA)$(BN).yaml
 
 .PHONY: data
 data: package-data wsa-data
-	helm install $(NAME-DATA) . $(WSA_CHECK-DATA) -f ../global.yaml
+	helm install $(NAME-DATA) . $(WAITERSACHECK-DATA) -f ../global.yaml
 
 .PHONY: upgrade-data
 upgrade-data: wsa-data package-data
-	helm upgrade $(NAME-DATA) . $(WSA_CHECK-DATA) -f ../global.yaml
+	helm upgrade $(NAME-DATA) . $(WAITERSACHECK-DATA) -f ../global.yaml
 
 .PHONY: remove-data
 remove-data:

--- a/edge/.helmignore
+++ b/edge/.helmignore
@@ -1,1 +1,5 @@
+Makefile
+configure.md
+logs
+build-number.txt
 *.bak

--- a/edge/Chart.yaml
+++ b/edge/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.1
 description: A Helm chart to deploy Grey Matter Edge
 name: edge
-version: 3.0.3
+version: 3.0.4
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: greymatter-io

--- a/edge/Makefile
+++ b/edge/Makefile
@@ -2,27 +2,17 @@ include ../helpers.mk
 
 NAME-EDGE := edge-$(CUST)-$(RAND)
 
-pwd_name := $(notdir $(PWD))
+.PHONY: edge upgrade-edge clean-edge remove-edge
 
-.PHONY: edge
 edge:
-	if [ "$(pwd_name)" == "edge" ]; then \
-		echo "run in makefile directory"; \
-		helm install $(NAME-EDGE) . -f ../global.yaml; \
-	else \
-		echo "run in helm-charts top directory"; \
-		helm install $(NAME-EDGE) edge -f ../global.yaml; \
-	fi
+	helm install $(NAME-EDGE) . -f ../global.yaml; \
 
-.PHONY: upgrade-edge
 upgrade-edge: package-edge
 	helm upgrade $(NAME-EDGE) . -f ../global.yaml
 
-.PHONY: clean-edge
 clean-edge:
 	rm -f ./charts/*
 
-.PHONY: remove-edge
 remove-edge:
 	helm uninstall $(NAME-EDGE)
 	

--- a/edge/Makefile
+++ b/edge/Makefile
@@ -1,12 +1,8 @@
-SHELL := /bin/bash
-YQCMD := docker run -i docker.greymatter.io/internal/yq:2.4.1
-CUST := $(shell cat ../global.yaml | $(YQCMD) -r '.global.release.customer' )
-RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}')
+include ../helpers.mk
+
 NAME-EDGE := edge-$(CUST)-$(RAND)
 
 pwd_name := $(notdir $(PWD))
-
-include ../output.mk
 
 .PHONY: edge
 edge:

--- a/edge/Makefile
+++ b/edge/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 current_dir := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
-CUST := development
+CUST := $(shell cat ../global.yaml | docker run -i docker.greymatter.io/internal/yq:2.4.1 -r '.global.release.customer' )
 # CUST := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.customer}')
 RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}')
 NAME-EDGE := edge-$(CUST)-$(RAND)
@@ -35,6 +35,3 @@ remove-edge:
 template-edge: $(BUILD_NUMBER_FILE)
 	mkdir -p $(OUTPUT_PATH)
 	helm template edge . --set=global.environment=kubernetes  -f ../global.yaml > $(OUTPUT_PATH)/helm-edge$(BN).yaml
-
-print:
-	echo $(RAND)

--- a/edge/Makefile
+++ b/edge/Makefile
@@ -1,7 +1,10 @@
 SHELL := /bin/bash
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 current_dir := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
-NAME-EDGE := edge
+CUST := development
+# CUST := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.customer}')
+RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}')
+NAME-EDGE := edge-$(CUST)-$(RAND)
 
 pwd_name := $(notdir $(PWD))
 
@@ -27,8 +30,11 @@ clean-edge:
 
 .PHONY: remove-edge
 remove-edge:
-	helm uninstall edge
+	helm uninstall $(NAME-EDGE)
 	
 template-edge: $(BUILD_NUMBER_FILE)
 	mkdir -p $(OUTPUT_PATH)
 	helm template edge . --set=global.environment=kubernetes  -f ../global.yaml > $(OUTPUT_PATH)/helm-edge$(BN).yaml
+
+print:
+	echo $(RAND)

--- a/edge/Makefile
+++ b/edge/Makefile
@@ -1,8 +1,6 @@
 SHELL := /bin/bash
-mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
-current_dir := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
-CUST := $(shell cat ../global.yaml | docker run -i docker.greymatter.io/internal/yq:2.4.1 -r '.global.release.customer' )
-# CUST := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.customer}')
+YQCMD := docker run -i docker.greymatter.io/internal/yq:2.4.1
+CUST := $(shell cat ../global.yaml | $(YQCMD) -r '.global.release.customer' )
 RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}')
 NAME-EDGE := edge-$(CUST)-$(RAND)
 

--- a/fabric/.helmignore
+++ b/fabric/.helmignore
@@ -1,1 +1,5 @@
+Makefile
+configure.md
+logs
+build-number.txt
 *.bak

--- a/fabric/Chart.yaml
+++ b/fabric/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.3.0
 description: A Helm chart to deploy Grey Matter Fabric
 name: fabric
-version: 3.0.9
+version: 3.0.10
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/fabric/Makefile
+++ b/fabric/Makefile
@@ -1,11 +1,7 @@
-SHELL := /bin/bash
-CHART-FABRIC := .
-YQCMD := docker run -i docker.greymatter.io/internal/yq:2.4.1
-CUST := $(shell cat ../global.yaml | $(YQCMD) -r '.global.release.customer' )
-RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}')
+include ../helpers.mk
+
 NAME-FABRIC := fabric-$(CUST)-$(RAND)
 
-include ../output.mk
 
 wsa-fabric:
 	$(eval WAITERSACHECK-FABRIC=$(shell kubectl get sa waiter-sa 2> /dev/null | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}'))

--- a/fabric/Makefile
+++ b/fabric/Makefile
@@ -6,16 +6,16 @@ NAME-FABRIC := fabric-$(CUST)-$(RAND)
 .PHONY: control control-api jwt jwt-gov fabric upgrade-fabric remove-fabric
 
 control:
-	helm install $(NAME-FABRIC) control $(WSA_CHECK) -f ../global.yaml
+	helm install $(NAME-FABRIC) control $(WSA_CHECK) -f $(HOME)/global.yaml
 
 control-api:
-	helm install control-api-$(NAME-FABRIC) control-api $(WSA_CHECK) -f ../global.yaml
+	helm install control-api-$(NAME-FABRIC) control-api $(WSA_CHECK) -f $(HOME)/global.yaml
 
 jwt: wsa-data
-	helm install jwt-$(NAME-FABRIC) jwt $(WSA_CHECK) -f ../global.yaml
+	helm install jwt-$(NAME-FABRIC) jwt $(WSA_CHECK) -f $(HOME)/global.yaml
 
 jwt-gov: wsa-data
-	helm install $(NAME-FABRIC) jwt-gov $(WSA_CHECK) -f ../global.yaml
+	helm install $(NAME-FABRIC) jwt-gov $(WSA_CHECK) -f $(HOME)/global.yaml
 
 clean-fabric:
 	rm -f ./charts/*
@@ -26,13 +26,13 @@ package-fabric: clean-fabric
 
 template-fabric: package-fabric $(BUILD_NUMBER_FILE)
 	mkdir -p $(OUTPUT_PATH)
-	helm template $(NAME-FABRIC) . $(WSA_CHECK)  -f ../global.yaml > $(OUTPUT_PATH)/helm-$(NAME-FABRIC)$(BN).yaml
+	helm template $(NAME-FABRIC) . $(WSA_CHECK)  -f $(HOME)/global.yaml > $(OUTPUT_PATH)/helm-$(NAME-FABRIC)$(BN).yaml
 
 fabric: package-fabric
-	helm install $(NAME-FABRIC) . $(WSA_CHECK) -f ../global.yaml
+	helm install $(NAME-FABRIC) . $(WSA_CHECK) -f $(HOME)/global.yaml
 
 upgrade-fabric: package-fabric
-	helm upgrade $(NAME-FABRIC) . $(WSA_CHECK) -f ../global.yaml --no-hooks
+	helm upgrade $(NAME-FABRIC) . $(WSA_CHECK) -f $(HOME)/global.yaml --no-hooks
 
 
 remove-fabric:

--- a/fabric/Makefile
+++ b/fabric/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 CHART-FABRIC := .
-CUST := development
+CUST := $(shell cat ../global.yaml | docker run -i docker.greymatter.io/internal/yq:2.4.1 -r '.global.release.customer' )
 RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}')
 NAME-FABRIC := fabric-$(CUST)-$(RAND)
 

--- a/fabric/Makefile
+++ b/fabric/Makefile
@@ -1,6 +1,8 @@
 SHELL := /bin/bash
-NAME-FABRIC:=fabric
 CHART-FABRIC := .
+CUST := development
+RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}')
+NAME-FABRIC := fabric-$(CUST)-$(RAND)
 
 include ../output.mk
 

--- a/fabric/Makefile
+++ b/fabric/Makefile
@@ -1,6 +1,7 @@
 SHELL := /bin/bash
 CHART-FABRIC := .
-CUST := $(shell cat ../global.yaml | docker run -i docker.greymatter.io/internal/yq:2.4.1 -r '.global.release.customer' )
+YQCMD := docker run -i docker.greymatter.io/internal/yq:2.4.1
+CUST := $(shell cat ../global.yaml | $(YQCMD) -r '.global.release.customer' )
 RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}')
 NAME-FABRIC := fabric-$(CUST)-$(RAND)
 

--- a/fabric/Makefile
+++ b/fabric/Makefile
@@ -3,24 +3,19 @@ include ../helpers.mk
 NAME-FABRIC := fabric-$(CUST)-$(RAND)
 
 
-wsa-fabric:
-	$(eval WAITERSACHECK-FABRIC=$(shell kubectl get sa waiter-sa 2> /dev/null | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}'))
+.PHONY: control control-api jwt jwt-gov fabric upgrade-fabric remove-fabric
 
-.PHONY: control
-control: wsa-fabric
-	helm install $(NAME-FABRIC) control $(WAITERSACHECK-FABRIC) -f ../global.yaml
+control:
+	helm install $(NAME-FABRIC) control $(WSA_CHECK) -f ../global.yaml
 
-.PHONY: control-api
-control-api: wsa-fabric
-	helm install control-api-$(NAME-FABRIC) control-api $(WAITERSACHECK-FABRIC) -f ../global.yaml
+control-api:
+	helm install control-api-$(NAME-FABRIC) control-api $(WSA_CHECK) -f ../global.yaml
 
-.PHONY: jwt
 jwt: wsa-data
-	helm install jwt-$(NAME-FABRIC) jwt $(WAITERSACHECK-FABRIC) -f ../global.yaml
+	helm install jwt-$(NAME-FABRIC) jwt $(WSA_CHECK) -f ../global.yaml
 
-.PHONY: jwt-gov
 jwt-gov: wsa-data
-	helm install $(NAME-FABRIC) jwt-gov $(WAITERSACHECK-FABRIC) -f ../global.yaml
+	helm install $(NAME-FABRIC) jwt-gov $(WSA_CHECK) -f ../global.yaml
 
 clean-fabric:
 	rm -f ./charts/*
@@ -31,17 +26,14 @@ package-fabric: clean-fabric
 
 template-fabric: package-fabric $(BUILD_NUMBER_FILE)
 	mkdir -p $(OUTPUT_PATH)
-	helm template $(NAME-FABRIC) . $(WAITERSACHECK-FABRIC)  -f ../global.yaml > $(OUTPUT_PATH)/helm-$(NAME-FABRIC)$(BN).yaml
+	helm template $(NAME-FABRIC) . $(WSA_CHECK)  -f ../global.yaml > $(OUTPUT_PATH)/helm-$(NAME-FABRIC)$(BN).yaml
 
-.PHONY: fabric
-fabric: package-fabric wsa-fabric
-	helm install $(NAME-FABRIC) . $(WAITERSACHECK-FABRIC) -f ../global.yaml
+fabric: package-fabric
+	helm install $(NAME-FABRIC) . $(WSA_CHECK) -f ../global.yaml
 
-.PHONY: upgrade-fabric
-upgrade-fabric: package-fabric wsa-fabric
-	helm upgrade $(NAME-FABRIC) . $(WAITERSACHECK-FABRIC) -f ../global.yaml --no-hooks
+upgrade-fabric: package-fabric
+	helm upgrade $(NAME-FABRIC) . $(WSA_CHECK) -f ../global.yaml --no-hooks
 
 
-.PHONY: remove-fabric
 remove-fabric:
 	helm uninstall $(NAME-FABRIC)

--- a/global.yaml
+++ b/global.yaml
@@ -19,11 +19,11 @@ global:
     # The label Control uses to find pods to include in the mesh
     cluster_label: greymatter.io/control
     # Comma delimited string of namespaces for control to monitor. Also used by prometheus.
-    additional_namespaces:
+    additional_namespaces: ""
   
   release:
     # release.production: true will increase all (except control-api) replicas to the default_replicas.  Otherwise the default for each chart will be used
-    customer: development
+    customer: greymatter-dev
     production: false
     default_replicas: 3
 

--- a/global.yaml
+++ b/global.yaml
@@ -23,7 +23,7 @@ global:
   
   release:
     # release.production: true will increase all (except control-api) replicas to the default_replicas.  Otherwise the default for each chart will be used
-    customer: greymatter-dev
+    customer: "greymatter-dev"
     production: false
     default_replicas: 3
 

--- a/global.yaml
+++ b/global.yaml
@@ -23,6 +23,7 @@ global:
   
   release:
     # release.production: true will increase all (except control-api) replicas to the default_replicas.  Otherwise the default for each chart will be used
+    customer: development
     production: false
     default_replicas: 3
 

--- a/helpers.mk
+++ b/helpers.mk
@@ -7,9 +7,9 @@ CUST := $(shell cat $(HOME)/global.yaml | $(YQCMD) -r '.global.release.customer'
 RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}' 2> /dev/null )
 
 # Colors
-ccred := $(shell tput setaf 255)
-ccyellow := $(shell tput setaf 225)
-ccend := $(shell tput setaf 000)
+ccred := $(shell echo '\033[0;31m')
+ccyellow := $(shell echo '\033[0;33m')
+ccend := $(shell echo '\033[0m')
 
 # Service account creation is set to true by default and this automates the disableing of these in makefiles
 WSA_CHECK := $(shell kubectl get sa waiter-sa 2> /dev/null | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}')
@@ -45,6 +45,7 @@ env:
 verify-identity-exists:
 	@kubectl get configmap greymatter-mesh-identity-$(CUST) || (echo -e "The mesh identity [greymatter-mesh-identity-$(CUST)] does not exist.\nRun $$(ccyellow)\"make restore-identity\"$$(ccend) to resore it before uninstalling the mesh." && exit 20)
 
+.PHONY: test
 test:
 	(echo -e "The mesh identity [greymatter-mesh-identity-$(CUST)] does not exist.\nRun $$(ccyellow)\"make restore-identity\"$$(ccend) to resore it before uninstalling the mesh." && exit 20)
 

--- a/helpers.mk
+++ b/helpers.mk
@@ -9,3 +9,11 @@ $(BUILD_NUMBER_FILE):
 OUTPUT_PATH=./logs
 
 BN=$$(cat $(BUILD_NUMBER_FILE))
+
+SHELL := /bin/bash
+
+# These are used for the helm release name
+YQCMD := docker run -i docker.greymatter.io/internal/yq:2.4.1
+CUST := $(shell cat ../global.yaml | $(YQCMD) -r '.global.release.customer' )
+RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}')
+

--- a/helpers.mk
+++ b/helpers.mk
@@ -43,7 +43,7 @@ env:
 	@echo "Environment: $(ENVIRONMENT)"
 
 verify-identity-exists:
-	@kubectl get configmap greymatter-mesh-identity-$(CUST) || (echo -e "The mesh identity [greymatter-mesh-identity-$(CUST)] does not exist.\nRun $$(ccyellow)\"make restore-identity\"$$(ccend) to resore it before uninstalling the mesh." && exit 20)
+	@kubectl get configmap greymatter-mesh-identity-$(CUST) || (echo -e "\nThe mesh identity [greymatter-mesh-identity-$(CUST)] does not exist.\nRun $$(ccyellow)\"make restore-identity\"$$(ccend) to resore it before uninstalling the mesh.\n" && exit 20)
 
 .PHONY: test
 test:

--- a/helpers.mk
+++ b/helpers.mk
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 HOME := $(shell git rev-parse --show-toplevel)
 # These are used for the helm release name (to uninstall and install and put inplace the mesh identity configmap)
 YQCMD := docker run -i docker.greymatter.io/internal/yq:2.4.1
-CUST := $(shell cat $(HOME)/global.yaml | $(YQCMD) -r '.global.release.customer' )
+CUST := $(shell cat $(HOME)/global.yaml | $(YQCMD) -r '.global.release.customer' | sed -E "s/[^[:alpha:].-]/-/g" )
 RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}' 2> /dev/null )
 
 # Colors

--- a/helpers.mk
+++ b/helpers.mk
@@ -45,9 +45,11 @@ verify-identity-exists:
 remove-identity:
 	kubectl delete configmap greymatter-mesh-identity-$(CUST)
 
-restore-identity:
+get-secret-release:
 	rm -f temp-secret.yaml
 	helm ls -o yaml | $(YQCMD) '.[] | select (.name | test("secret") )' > temp-secret.yaml
+
+restore-identity: get-secret-release
 	$(unset SECRET_RELEASE_NAME)
 	$(unset SECRET_REVISION)
 	$(eval SECRET_RELEASE_NAME=$(shell cat temp-secret.yaml | $(YQCMD) -r .name ))

--- a/helpers.mk
+++ b/helpers.mk
@@ -7,9 +7,9 @@ CUST := $(shell cat $(HOME)/global.yaml | $(YQCMD) -r '.global.release.customer'
 RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}' 2> /dev/null )
 
 # Colors
-ccred := $(tput setaf 255)
-ccyellow := $(tput setaf 225)
-ccend := $(tput setaf 000)
+ccred := $(shell tput setaf 255)
+ccyellow := $(shell tput setaf 225)
+ccend := $(shell tput setaf 000)
 
 # Service account creation is set to true by default and this automates the disableing of these in makefiles
 WSA_CHECK := $(shell kubectl get sa waiter-sa 2> /dev/null | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}')

--- a/helpers.mk
+++ b/helpers.mk
@@ -1,5 +1,22 @@
-BUILD_NUMBER_FILE=build-number.txt
+# Shell sets the default behaviour for all shell functions running in the makefiles
+SHELL := /bin/bash
 
+# These are used for the helm release name (to uninstall and install and put inplace the mesh identity configmap)
+YQCMD := docker run -i docker.greymatter.io/internal/yq:2.4.1
+CUST := $(shell cat ../global.yaml | $(YQCMD) -r '.global.release.customer' )
+RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}')
+
+# Service account creation is set to true by default and this automates the disableing of these in makefiles
+WSA_CHECK := $(shell kubectl get sa waiter-sa 2> /dev/null | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}')
+
+# Used in sense
+HELM_VALIDATION := $(shell helm version --short | cut -d'+' -f1 | awk -Fv '{if ($$2 > 3.2) print "--disable-openapi-validation"}')
+
+# gets the cluster environment
+ENVIRONMENT := $(shell grep -hri "environment:"  ../global.yaml  | cut -d ':' -f 2 | xargs)
+
+# This section is used to ensure that when a `make template x` a new file is created instead of ovewritting the same file
+BUILD_NUMBER_FILE=build-number.txt
 # We need to increment the version even if the build number file exists
 .PHONY: $(BUILD_NUMBER_FILE)
 # Build number file.  Increment if any object file changes.
@@ -7,13 +24,4 @@ $(BUILD_NUMBER_FILE):
 	@if ! test -f $(BUILD_NUMBER_FILE); then echo 0 > $(BUILD_NUMBER_FILE); fi
 	@echo $$(($$(cat $(BUILD_NUMBER_FILE)) + 1)) > $(BUILD_NUMBER_FILE)
 OUTPUT_PATH=./logs
-
 BN=$$(cat $(BUILD_NUMBER_FILE))
-
-SHELL := /bin/bash
-
-# These are used for the helm release name
-YQCMD := docker run -i docker.greymatter.io/internal/yq:2.4.1
-CUST := $(shell cat ../global.yaml | $(YQCMD) -r '.global.release.customer' )
-RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}')
-

--- a/helpers.mk
+++ b/helpers.mk
@@ -47,7 +47,7 @@ verify-identity-exists:
 
 .PHONY: test
 test:
-	(echo -e "The mesh identity [greymatter-mesh-identity-$(CUST)] does not exist.\nRun $$(ccyellow)\"make restore-identity\"$$(ccend) to resore it before uninstalling the mesh." && exit 20)
+	(echo -e "The mesh identity [greymatter-mesh-identity-$(CUST)] does not exist.\nRun $(ccyellow)\"make restore-identity\"$(ccend) to resore it before uninstalling the mesh." && exit 20)
 
 remove-identity:
 	kubectl delete configmap greymatter-mesh-identity-$(CUST)

--- a/helpers.mk
+++ b/helpers.mk
@@ -1,10 +1,12 @@
 # Shell sets the default behaviour for all shell functions running in the makefiles
 SHELL := /bin/bash
-
+HOME := $(shell git rev-parse --show-toplevel)
 # These are used for the helm release name (to uninstall and install and put inplace the mesh identity configmap)
 YQCMD := docker run -i docker.greymatter.io/internal/yq:2.4.1
-CUST := $(shell cat ../global.yaml | $(YQCMD) -r '.global.release.customer' )
-RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}' 2> /dev/null)
+CUST := $(shell cat $(HOME)/global.yaml | $(YQCMD) -r '.global.release.customer' )
+RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}' 2> /dev/null )
+
+
 
 # Service account creation is set to true by default and this automates the disableing of these in makefiles
 WSA_CHECK := $(shell kubectl get sa waiter-sa 2> /dev/null | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}')
@@ -13,7 +15,7 @@ WSA_CHECK := $(shell kubectl get sa waiter-sa 2> /dev/null | tail -n +2 | awk '{
 HELM_VALIDATION := $(shell helm version --short | cut -d'+' -f1 | awk -Fv '{if ($$2 > 3.2) print "--disable-openapi-validation"}')
 
 # gets the cluster environment
-ENVIRONMENT := $(shell cat ../global.yaml | $(YQCMD) -r '.global.environment')
+ENVIRONMENT := $(shell cat $(HOME)/global.yaml | $(YQCMD) -r '.global.environment')
 
 #####  This section is used to ensure that when a `make template x` 
 #####  a new file is created instead of ovewritting the same file
@@ -26,3 +28,32 @@ $(BUILD_NUMBER_FILE):
 	@echo $$(($$(cat $(BUILD_NUMBER_FILE)) + 1)) > $(BUILD_NUMBER_FILE)
 OUTPUT_PATH=./logs
 BN=$$(cat $(BUILD_NUMBER_FILE))
+
+
+cust:
+	@echo "Cust: $(CUST)"
+
+home:
+	@echo "Home: $(HOME)"
+
+env:
+	@echo "Environment: $(ENVIRONMENT)"
+
+verify-identity-exists:
+	@kubectl get configmap greymatter-mesh-identity-$(CUST) || (echo "The mesh identity [greymatter-mesh-identity-$(CUST)] does not exist.  You will need to run \"make restore-identity\" to resore it before uninstalling the mesh." && exit 20)
+
+remove-identity:
+	kubectl delete configmap greymatter-mesh-identity-$(CUST)
+
+restore-identity:
+	rm -f temp-secret.yaml
+	helm ls -o yaml | $(YQCMD) '.[] | select (.name | test("secret") )' > temp-secret.yaml
+	$(unset SECRET_RELEASE_NAME)
+	$(unset SECRET_REVISION)
+	$(eval SECRET_RELEASE_NAME=$(shell cat temp-secret.yaml | $(YQCMD) -r .name ))
+	$(eval SECRET_REVISION=$(shell cat temp-secret.yaml | $(YQCMD) -r .revision ))
+	echo $(SECRET_RELEASE_NAME)
+	echo $(SECRET_REVISION)
+	helm rollback $(SECRET_RELEASE_NAME) $(SECRET_REVISION)
+	$(unset SECRET_RELEASE_NAME)
+	$(unset SECRET_REVISION)

--- a/helpers.mk
+++ b/helpers.mk
@@ -13,9 +13,10 @@ WSA_CHECK := $(shell kubectl get sa waiter-sa 2> /dev/null | tail -n +2 | awk '{
 HELM_VALIDATION := $(shell helm version --short | cut -d'+' -f1 | awk -Fv '{if ($$2 > 3.2) print "--disable-openapi-validation"}')
 
 # gets the cluster environment
-ENVIRONMENT := $(shell grep -hri "environment:"  ../global.yaml  | cut -d ':' -f 2 | xargs)
+ENVIRONMENT := $(shell cat ../global.yaml | $(YQCMD) -r '.global.environment')
 
-# This section is used to ensure that when a `make template x` a new file is created instead of ovewritting the same file
+#####  This section is used to ensure that when a `make template x` 
+#####  a new file is created instead of ovewritting the same file
 BUILD_NUMBER_FILE=build-number.txt
 # We need to increment the version even if the build number file exists
 .PHONY: $(BUILD_NUMBER_FILE)

--- a/helpers.mk
+++ b/helpers.mk
@@ -4,7 +4,7 @@ SHELL := /bin/bash
 # These are used for the helm release name (to uninstall and install and put inplace the mesh identity configmap)
 YQCMD := docker run -i docker.greymatter.io/internal/yq:2.4.1
 CUST := $(shell cat ../global.yaml | $(YQCMD) -r '.global.release.customer' )
-RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}')
+RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}' 2> /dev/null)
 
 # Service account creation is set to true by default and this automates the disableing of these in makefiles
 WSA_CHECK := $(shell kubectl get sa waiter-sa 2> /dev/null | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}')

--- a/helpers.mk
+++ b/helpers.mk
@@ -6,7 +6,10 @@ YQCMD := docker run -i docker.greymatter.io/internal/yq:2.4.1
 CUST := $(shell cat $(HOME)/global.yaml | $(YQCMD) -r '.global.release.customer' )
 RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}' 2> /dev/null )
 
-
+# Colors
+ccred := $(tput setaf 255)
+ccyellow := $(tput setaf 225)
+ccend := $(tput setaf 000)
 
 # Service account creation is set to true by default and this automates the disableing of these in makefiles
 WSA_CHECK := $(shell kubectl get sa waiter-sa 2> /dev/null | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}')
@@ -40,7 +43,10 @@ env:
 	@echo "Environment: $(ENVIRONMENT)"
 
 verify-identity-exists:
-	@kubectl get configmap greymatter-mesh-identity-$(CUST) || (echo "The mesh identity [greymatter-mesh-identity-$(CUST)] does not exist.  You will need to run \"make restore-identity\" to resore it before uninstalling the mesh." && exit 20)
+	@kubectl get configmap greymatter-mesh-identity-$(CUST) || (echo -e "The mesh identity [greymatter-mesh-identity-$(CUST)] does not exist.\nRun $$(ccyellow)\"make restore-identity\"$$(ccend) to resore it before uninstalling the mesh." && exit 20)
+
+test:
+	(echo -e "The mesh identity [greymatter-mesh-identity-$(CUST)] does not exist.\nRun $$(ccyellow)\"make restore-identity\"$$(ccend) to resore it before uninstalling the mesh." && exit 20)
 
 remove-identity:
 	kubectl delete configmap greymatter-mesh-identity-$(CUST)

--- a/secrets/.helmignore
+++ b/secrets/.helmignore
@@ -1,1 +1,3 @@
 *.bak
+Makefile
+configuration.md

--- a/secrets/Chart.yaml
+++ b/secrets/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy secrets
 name: secrets
-version: 2.3.0
+version: 2.3.1
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/secrets/Makefile
+++ b/secrets/Makefile
@@ -28,7 +28,7 @@ remove-secrets:
 
 values-validation:
 	# Ensure that the rds.enabled is true in secrets and in fabric values files
-	@if [ "$(shell cat values.yaml | grep -A1 rds | grep enabled: | awk '{print $$2}')" == "$(shell cat ../sense/values.yaml | grep -A1 rds | grep enabled: | awk '{print $$2}')" ]; then \
+	if [ "$(shell cat values.yaml | $(YQCMD) -r '.postgres.rds.enabled')" == "$(shell cat ../sense/values.yaml | g$(YQCMD) -r '.postgres.rds.enabled')" ]; then \
 		echo "rds.enabled in secrets/values.yaml and sense/values.yaml match"; \
 	else \
 		echo "rds.enabled in secrets/values.yaml and sense/values.yaml DO NOT MATCH.  Secrets will not be created"; \

--- a/secrets/Makefile
+++ b/secrets/Makefile
@@ -1,5 +1,6 @@
 SHELL := /bin/bash
-NAME-SECRET:=secrets-dev
+CUST := $(shell cat ../global.yaml | docker run -i docker.greymatter.io/internal/yq:2.4.1 -r '.global.release.customer' )
+NAME-SECRET:=secrets-$(CUST)
 
 include ../output.mk
 

--- a/secrets/Makefile
+++ b/secrets/Makefile
@@ -28,7 +28,7 @@ remove-secrets:
 
 values-validation:
 	# Ensure that the rds.enabled is true in secrets and in fabric values files
-	if [ "$(shell cat values.yaml | $(YQCMD) -r '.postgres.rds.enabled')" == "$(shell cat ../sense/values.yaml | g$(YQCMD) -r '.postgres.rds.enabled')" ]; then \
+	if [ "$(shell cat values.yaml | $(YQCMD) -r '.postgres.rds.enabled')" == "$(shell cat ../sense/values.yaml | $(YQCMD) -r '.postgres.rds.enabled')" ]; then \
 		echo "rds.enabled in secrets/values.yaml and sense/values.yaml match"; \
 	else \
 		echo "rds.enabled in secrets/values.yaml and sense/values.yaml DO NOT MATCH.  Secrets will not be created"; \

--- a/secrets/Makefile
+++ b/secrets/Makefile
@@ -5,21 +5,21 @@ NAME-SECRET:=secrets-$(CUST)
 .PHONY: credentials secrets upgrade-secrets remove-secrets
 
 credentials:
-	./../ci/scripts/build-credentials.sh
+	./$(HOME)/ci/scripts/build-credentials.sh
 
 copy-credentials:
-	cp ../credentials.yaml .
+	cp $(HOME)/credentials.yaml .
 
 template-secrets: $(BUILD_NUMBER_FILE)
 	mkdir -p $(OUTPUT_PATH)
-	helm template $(NAME-SECRET) . --set=global.environment=kubernetes   -f ../credentials.yaml -f ../global.yaml > $(OUTPUT_PATH)/helm-secrets$(BN).yaml
+	helm template $(NAME-SECRET) . --set=global.environment=kubernetes   -f $(HOME)/credentials.yaml -f $(HOME)/global.yaml > $(OUTPUT_PATH)/helm-secrets$(BN).yaml
 
 secrets: copy-credentials values-validation
-	helm install $(NAME-SECRET) . -f credentials.yaml -f ../global.yaml
+	helm install $(NAME-SECRET) . -f credentials.yaml -f $(HOME)/global.yaml
 	rm credentials.yaml
 
 upgrade-secrets: copy-credentials values-validation
-	helm upgrade $(NAME-SECRET) . -f credentials.yaml -f ../global.yaml --install 
+	helm upgrade $(NAME-SECRET) . -f credentials.yaml -f $(HOME)/global.yaml --install 
 	rm credentials.yaml
 
 remove-secrets:
@@ -28,7 +28,7 @@ remove-secrets:
 
 values-validation:
 	# Ensure that the rds.enabled is true in secrets and in fabric values files
-	if [ "$(shell cat values.yaml | $(YQCMD) -r '.postgres.rds.enabled')" == "$(shell cat ../sense/values.yaml | $(YQCMD) -r '.slo.postgres.rds.enabled')" ]; then \
+	if [ "$(shell cat values.yaml | $(YQCMD) -r '.postgres.rds.enabled')" == "$(shell cat $(HOME)/sense/values.yaml | $(YQCMD) -r '.slo.postgres.rds.enabled')" ]; then \
 		echo "rds.enabled in secrets/values.yaml and sense/values.yaml match"; \
 	else \
 		echo "rds.enabled in secrets/values.yaml and sense/values.yaml DO NOT MATCH.  Secrets will not be created"; \

--- a/secrets/Makefile
+++ b/secrets/Makefile
@@ -1,5 +1,6 @@
 SHELL := /bin/bash
-CUST := $(shell cat ../global.yaml | docker run -i docker.greymatter.io/internal/yq:2.4.1 -r '.global.release.customer' )
+YQCMD := docker run -i docker.greymatter.io/internal/yq:2.4.1
+CUST := $(shell cat ../global.yaml | $(YQCMD) -r '.global.release.customer' )
 NAME-SECRET:=secrets-$(CUST)
 
 include ../output.mk

--- a/secrets/Makefile
+++ b/secrets/Makefile
@@ -2,8 +2,8 @@ include ../helpers.mk
 
 NAME-SECRET:=secrets-$(CUST)
 
+.PHONY: credentials secrets upgrade-secrets remove-secrets
 
-.PHONY: credentials
 credentials:
 	./../ci/scripts/build-credentials.sh
 
@@ -14,17 +14,14 @@ template-secrets: $(BUILD_NUMBER_FILE)
 	mkdir -p $(OUTPUT_PATH)
 	helm template $(NAME-SECRET) . --set=global.environment=kubernetes   -f ../credentials.yaml -f ../global.yaml > $(OUTPUT_PATH)/helm-secrets$(BN).yaml
 
-.PHONY: secrets
 secrets: copy-credentials values-validation
 	helm install $(NAME-SECRET) . -f credentials.yaml -f ../global.yaml
 	rm credentials.yaml
 
-.PHONY: upgrade-secrets
 upgrade-secrets: copy-credentials values-validation
 	helm upgrade $(NAME-SECRET) . -f credentials.yaml -f ../global.yaml --install 
 	rm credentials.yaml
 
-.PHONY: remove-secrets
 remove-secrets:
 	helm uninstall $(NAME-SECRET)
 

--- a/secrets/Makefile
+++ b/secrets/Makefile
@@ -1,13 +1,7 @@
-SHELL := /bin/bash
-YQCMD := docker run -i docker.greymatter.io/internal/yq:2.4.1
-CUST := $(shell cat ../global.yaml | $(YQCMD) -r '.global.release.customer' )
+include ../helpers.mk
+
 NAME-SECRET:=secrets-$(CUST)
 
-include ../output.mk
-
-mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
-current_dir := $(notdir $(patsubst %/,%,$(dir $(mkfile_path))))
-pwd_name := $(notdir $(PWD))
 
 .PHONY: credentials
 credentials:

--- a/secrets/Makefile
+++ b/secrets/Makefile
@@ -1,4 +1,5 @@
 SHELL := /bin/bash
+NAME-SECRET:=secrets-dev
 
 include ../output.mk
 
@@ -15,21 +16,21 @@ copy-credentials:
 
 template-secrets: $(BUILD_NUMBER_FILE)
 	mkdir -p $(OUTPUT_PATH)
-	helm template secrets . --set=global.environment=kubernetes   -f ../credentials.yaml -f ../global.yaml > $(OUTPUT_PATH)/helm-secrets$(BN).yaml
+	helm template $(NAME-SECRET) . --set=global.environment=kubernetes   -f ../credentials.yaml -f ../global.yaml > $(OUTPUT_PATH)/helm-secrets$(BN).yaml
 
 .PHONY: secrets
 secrets: copy-credentials values-validation
-	helm install secrets . -f credentials.yaml -f ../global.yaml
+	helm install $(NAME-SECRET) . -f credentials.yaml -f ../global.yaml
 	rm credentials.yaml
 
 .PHONY: upgrade-secrets
 upgrade-secrets: copy-credentials values-validation
-	helm upgrade secrets . -f credentials.yaml -f ../global.yaml --install 
+	helm upgrade $(NAME-SECRET) . -f credentials.yaml -f ../global.yaml --install 
 	rm credentials.yaml
 
 .PHONY: remove-secrets
 remove-secrets:
-	helm uninstall secrets
+	helm uninstall $(NAME-SECRET)
 
 
 values-validation:

--- a/secrets/Makefile
+++ b/secrets/Makefile
@@ -28,7 +28,7 @@ remove-secrets:
 
 values-validation:
 	# Ensure that the rds.enabled is true in secrets and in fabric values files
-	if [ "$(shell cat values.yaml | $(YQCMD) -r '.postgres.rds.enabled')" == "$(shell cat ../sense/values.yaml | $(YQCMD) -r '.postgres.rds.enabled')" ]; then \
+	if [ "$(shell cat values.yaml | $(YQCMD) -r '.postgres.rds.enabled')" == "$(shell cat ../sense/values.yaml | $(YQCMD) -r '.slo.postgres.rds.enabled')" ]; then \
 		echo "rds.enabled in secrets/values.yaml and sense/values.yaml match"; \
 	else \
 		echo "rds.enabled in secrets/values.yaml and sense/values.yaml DO NOT MATCH.  Secrets will not be created"; \

--- a/secrets/templates/mesh-identity.yaml
+++ b/secrets/templates/mesh-identity.yaml
@@ -1,8 +1,10 @@
+{{ $customer_name := regexReplaceAll "\\W+" .Values.global.release.customer  "-" }}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: greymatter-mesh-identity-{{.Values.global.release.customer}}
+  name: greymatter-mesh-identity-{{ print $customer_name }}
   namespace: {{ $.Release.Namespace }}
 data:
-  customer: {{.Values.global.release.customer }}
+  customer: {{ print $customer_name }}
   rand_identifier: {{ randAlphaNum 6 | lower  }}

--- a/secrets/templates/mesh-identity.yaml
+++ b/secrets/templates/mesh-identity.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: greymatter-mesh-identity-{{.Values.global.release.customer}}
+  namespace: {{ $.Release.Namespace }}
+data:
+  customer: {{.Values.global.release.customer }}
+  rand_identifier: {{ randAlphaNum 6 | lower  }}

--- a/secrets/values.yaml
+++ b/secrets/values.yaml
@@ -6,6 +6,8 @@ global:
       from_file:
         enabled: false
   image_pull_secret: docker.secret
+  release:
+    customer: dev
 
 dockerCredentials:
   - registry: docker.greymatter.io

--- a/sense/.helmignore
+++ b/sense/.helmignore
@@ -1,1 +1,5 @@
+Makefile
+configure.md
+logs
+build-number.txt
 *.bak

--- a/sense/Chart.yaml
+++ b/sense/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.3.0
 description: A Helm chart to deploy Grey Matter Sense
 name: sense
-version: 3.0.7
+version: 3.0.8
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/sense/Makefile
+++ b/sense/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-CUST := development
+CUST := $(shell cat ../global.yaml | docker run -i docker.greymatter.io/internal/yq:2.4.1 -r '.global.release.customer' )
 RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}')
 NAME-SENSE := sense-$(CUST)-$(RAND)
 CHART-SENSE := .

--- a/sense/Makefile
+++ b/sense/Makefile
@@ -1,5 +1,6 @@
 SHELL := /bin/bash
-CUST := $(shell cat ../global.yaml | docker run -i docker.greymatter.io/internal/yq:2.4.1 -r '.global.release.customer' )
+YQCMD := docker run -i docker.greymatter.io/internal/yq:2.4.1
+CUST := $(shell cat ../global.yaml | $(YQCMD) -r '.global.release.customer' )
 RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}')
 NAME-SENSE := sense-$(CUST)-$(RAND)
 CHART-SENSE := .

--- a/sense/Makefile
+++ b/sense/Makefile
@@ -4,13 +4,13 @@ NAME-SENSE := sense-$(CUST)-$(RAND)
 .PHONY: catalog dashboard slo sense upgrade-sense remove-sense
 
 catalog:
-	helm install $(NAME-SENSE) catalog $(WSA_CHECK) -f ../global.yaml
+	helm install $(NAME-SENSE) catalog $(WSA_CHECK) -f $(HOME)/global.yaml
 
 dashboard:
-	helm install $(NAME-SENSE) dashboard $(WSA_CHECK) -f ../global.yaml
+	helm install $(NAME-SENSE) dashboard $(WSA_CHECK) -f $(HOME)/global.yaml
 
 slo:
-	helm install $(NAME-SENSE) slo $(WSA_CHECK) -f ../global.yaml
+	helm install $(NAME-SENSE) slo $(WSA_CHECK) -f $(HOME)/global.yaml
 
 clean-sense:
 	rm -f ./charts/*
@@ -20,13 +20,13 @@ package-sense: clean-sense
 
 template-sense: package-sense $(BUILD_NUMBER_FILE)
 	mkdir -p $(OUTPUT_PATH)
-	helm template $(NAME-SENSE) . $(WSA_CHECK)  -f ../global.yaml > $(OUTPUT_PATH)/helm-$(NAME-SENSE)$(BN).yaml
+	helm template $(NAME-SENSE) . $(WSA_CHECK)  -f $(HOME)/global.yaml > $(OUTPUT_PATH)/helm-$(NAME-SENSE)$(BN).yaml
 
 sense: package-sense
-	helm install $(NAME-SENSE) . $(WSA_CHECK) -f ../global.yaml --timeout 10m --wait
+	helm install $(NAME-SENSE) . $(WSA_CHECK) -f $(HOME)/global.yaml --timeout 10m --wait
 
 upgrade-sense: package-sense
-	helm upgrade $(NAME-SENSE) . $(WSA_CHECK) -f ../global.yaml --no-hooks --install $(HELM_VALIDATION)
+	helm upgrade $(NAME-SENSE) . $(WSA_CHECK) -f $(HOME)/global.yaml --no-hooks --install $(HELM_VALIDATION)
 
 remove-sense:
 	helm uninstall $(NAME-SENSE)

--- a/sense/Makefile
+++ b/sense/Makefile
@@ -1,5 +1,7 @@
 SHELL := /bin/bash
-NAME-SENSE:=sense
+CUST := development
+RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}')
+NAME-SENSE := sense-$(CUST)-$(RAND)
 CHART-SENSE := .
 
 include ../output.mk

--- a/sense/Makefile
+++ b/sense/Makefile
@@ -1,24 +1,16 @@
 include ../helpers.mk
 NAME-SENSE := sense-$(CUST)-$(RAND)
 
-wsa-sense:
-	$(eval WAITERSACHECK-SENSE=$(shell kubectl get sa waiter-sa 2> /dev/null | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}'))
+.PHONY: catalog dashboard slo sense upgrade-sense remove-sense
 
-helm-validator:
-	$(eval HELM_VALIDATION=$(shell helm version --short | cut -d'+' -f1 | awk -Fv '{if ($$2 > 3.2) print "--disable-openapi-validation"}'))
-	@echo $(HELM_VALIDATION)
+catalog:
+	helm install $(NAME-SENSE) catalog $(WSA_CHECK) -f ../global.yaml
 
-.PHONY: catalog
-catalog: wsa-sense
-	helm install $(NAME-SENSE) catalog $(WAITERSACHECK-SENSE) -f ../global.yaml
+dashboard:
+	helm install $(NAME-SENSE) dashboard $(WSA_CHECK) -f ../global.yaml
 
-.PHONY: dashboard
-dashboard: wsa-sense
-	helm install $(NAME-SENSE) dashboard $(WAITERSACHECK-SENSE) -f ../global.yaml
-
-.PHONY: slo
-slo: wsa-sense
-	helm install $(NAME-SENSE) slo $(WAITERSACHECK-SENSE) -f ../global.yaml
+slo:
+	helm install $(NAME-SENSE) slo $(WSA_CHECK) -f ../global.yaml
 
 clean-sense:
 	rm -f ./charts/*
@@ -28,16 +20,13 @@ package-sense: clean-sense
 
 template-sense: package-sense $(BUILD_NUMBER_FILE)
 	mkdir -p $(OUTPUT_PATH)
-	helm template $(NAME-SENSE) . $(WAITERSACHECK-SENSE)  -f ../global.yaml > $(OUTPUT_PATH)/helm-$(NAME-SENSE)$(BN).yaml
+	helm template $(NAME-SENSE) . $(WSA_CHECK)  -f ../global.yaml > $(OUTPUT_PATH)/helm-$(NAME-SENSE)$(BN).yaml
 
-.PHONY: sense
-sense: package-sense wsa-sense
-	helm install $(NAME-SENSE) . $(WAITERSACHECK-SENSE) -f ../global.yaml --timeout 10m --wait
+sense: package-sense
+	helm install $(NAME-SENSE) . $(WSA_CHECK) -f ../global.yaml --timeout 10m --wait
 
-.PHONY: upgrade-sense
-upgrade-sense: wsa-sense package-sense helm-validator
-	helm upgrade $(NAME-SENSE) . $(WAITERSACHECK-SENSE) -f ../global.yaml --no-hooks --install $(HELM_VALIDATION)
+upgrade-sense: package-sense
+	helm upgrade $(NAME-SENSE) . $(WSA_CHECK) -f ../global.yaml --no-hooks --install $(HELM_VALIDATION)
 
-.PHONY: remove-sense
 remove-sense:
 	helm uninstall $(NAME-SENSE)

--- a/sense/Makefile
+++ b/sense/Makefile
@@ -1,11 +1,5 @@
-SHELL := /bin/bash
-YQCMD := docker run -i docker.greymatter.io/internal/yq:2.4.1
-CUST := $(shell cat ../global.yaml | $(YQCMD) -r '.global.release.customer' )
-RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}')
+include ../helpers.mk
 NAME-SENSE := sense-$(CUST)-$(RAND)
-CHART-SENSE := .
-
-include ../output.mk
 
 wsa-sense:
 	$(eval WAITERSACHECK-SENSE=$(shell kubectl get sa waiter-sa 2> /dev/null | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}'))

--- a/spire/.helmignore
+++ b/spire/.helmignore
@@ -1,1 +1,3 @@
 *.bak
+Makefile
+configuration.md

--- a/spire/Chart.yaml
+++ b/spire/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Spire
 name: spire
-version: 2.2.4
+version: 2.2.5
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/spire/Makefile
+++ b/spire/Makefile
@@ -7,15 +7,15 @@ NAME-SPIRE-SERVER := spire-server-$(CUST)-$(RAND)
 
 
 server: 
-	helm install $(NAME-SPIRE-SERVER) server $(WSA_CHECK) -f ../global.yaml
+	helm install $(NAME-SPIRE-SERVER) server $(WSA_CHECK) -f $(HOME)/global.yaml
 
 agent:
 	@if [ "$(ENVIRONMENT)" == "openshift" ]; then \
-		helm install $(NAME-SPIRE-AGENT) agent $(WSA_CHECK) -f ../global.yaml; \
+		helm install $(NAME-SPIRE-AGENT) agent $(WSA_CHECK) -f $(HOME)/global.yaml; \
         oc adm policy add-scc-to-user hostaccess system:serviceaccount:spire:agent;\
 		oc adm policy add-scc-to-user privileged system:serviceaccount:spire:agent;\
 	else \
-		helm install $(NAME-SPIRE-AGENT) agent $(WSA_CHECK) -f ../global.yaml; \
+		helm install $(NAME-SPIRE-AGENT) agent $(WSA_CHECK) -f $(HOME)/global.yaml; \
     fi
 
 clean-spire:
@@ -27,8 +27,8 @@ package-spire: clean-spire
 
 template-spire: package-spire $(BUILD_NUMBER_FILE)
 	mkdir -p $(OUTPUT_PATH)
-	helm template $(NAME-SPIRE-AGENT) agent $(WSA_CHECK)  -f ../global.yaml > $(OUTPUT_PATH)/helm-$(NAME-SPIRE-AGENT)$(BN).yaml
-	helm template $(NAME-SPIRE-SERVER) agent $(WSA_CHECK)  -f ../global.yaml > $(OUTPUT_PATH)/helm-$(NAME-SPIRE-SERVER)$(BN).yaml
+	helm template $(NAME-SPIRE-AGENT) agent $(WSA_CHECK)  -f $(HOME)/global.yaml > $(OUTPUT_PATH)/helm-$(NAME-SPIRE-AGENT)$(BN).yaml
+	helm template $(NAME-SPIRE-SERVER) agent $(WSA_CHECK)  -f $(HOME)/global.yaml > $(OUTPUT_PATH)/helm-$(NAME-SPIRE-SERVER)$(BN).yaml
 
 spire: package-spire 
 	(make server && sleep 20 && make agent)
@@ -39,3 +39,6 @@ remove-spire:
 
 custom-ca:
 	./../ci/scripts/spire-ca.sh
+
+env:
+	echo $(ENVIRONMENT)

--- a/spire/Makefile
+++ b/spire/Makefile
@@ -1,5 +1,6 @@
 SHELL := /bin/bash
-CUST := $(shell cat ../global.yaml | docker run -i docker.greymatter.io/internal/yq:2.4.1 -r '.global.release.customer' )
+YQCMD := docker run -i docker.greymatter.io/internal/yq:2.4.1
+CUST := $(shell cat ../global.yaml | $(YQCMD) -r '.global.release.customer' )
 RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}')
 NAME-SPIRE := spire-$(CUST)-$(RAND)
 CHART-SPIRE := .

--- a/spire/Makefile
+++ b/spire/Makefile
@@ -3,25 +3,19 @@ include ../helpers.mk
 NAME-SPIRE-AGENT := spire-agent-$(CUST)-$(RAND)
 NAME-SPIRE-SERVER := spire-server-$(CUST)-$(RAND)
 
+.PHONY: server agent spire remove-spire custom-ca
 
-wsa-spire:
-	$(eval WAITERSACHECK-SPIRE=$(shell kubectl get sa waiter-sa 2> /dev/null | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}'))
 
-envirionemt-check:
-	$(eval ENVIRONMENT=$(shell grep -hri "environment:"  ../global.yaml  | cut -d ':' -f 2 | xargs))
+server: 
+	helm install $(NAME-SPIRE-SERVER) server $(WSA_CHECK) -f ../global.yaml
 
-.PHONY: server
-server: wsa-spire
-	helm install $(NAME-SPIRE-SERVER) server $(WAITERSACHECK-SPIRE) -f ../global.yaml
-
-.PHONY: agent
-agent: wsa-spire envirionemt-check
+agent:
 	@if [ "$(ENVIRONMENT)" == "openshift" ]; then \
-		helm install $(NAME-SPIRE-AGENT) agent $(WAITERSACHECK-SPIRE) -f ../global.yaml; \
+		helm install $(NAME-SPIRE-AGENT) agent $(WSA_CHECK) -f ../global.yaml; \
         oc adm policy add-scc-to-user hostaccess system:serviceaccount:spire:agent;\
 		oc adm policy add-scc-to-user privileged system:serviceaccount:spire:agent;\
 	else \
-		helm install $(NAME-SPIRE-AGENT) agent $(WAITERSACHECK-SPIRE) -f ../global.yaml; \
+		helm install $(NAME-SPIRE-AGENT) agent $(WSA_CHECK) -f ../global.yaml; \
     fi
 
 clean-spire:
@@ -33,19 +27,15 @@ package-spire: clean-spire
 
 template-spire: package-spire $(BUILD_NUMBER_FILE)
 	mkdir -p $(OUTPUT_PATH)
-	helm template $(NAME-SPIRE-AGENT) agent $(WAITERSACHECK-SPIRE)  -f ../global.yaml > $(OUTPUT_PATH)/helm-$(NAME-SPIRE-AGENT)$(BN).yaml
-	helm template $(NAME-SPIRE-SERVER) agent $(WAITERSACHECK-SPIRE)  -f ../global.yaml > $(OUTPUT_PATH)/helm-$(NAME-SPIRE-SERVER)$(BN).yaml
+	helm template $(NAME-SPIRE-AGENT) agent $(WSA_CHECK)  -f ../global.yaml > $(OUTPUT_PATH)/helm-$(NAME-SPIRE-AGENT)$(BN).yaml
+	helm template $(NAME-SPIRE-SERVER) agent $(WSA_CHECK)  -f ../global.yaml > $(OUTPUT_PATH)/helm-$(NAME-SPIRE-SERVER)$(BN).yaml
 
-.PHONY: spire
-spire: package-spire wsa-spire
+spire: package-spire 
 	(make server && sleep 20 && make agent)
 
-.PHONY: remove-spire
 remove-spire:
 	helm uninstall $(NAME-SPIRE-AGENT)
 	helm uninstall $(NAME-SPIRE-SERVER)
 
-.PHONY: custom-ca
 custom-ca:
 	./../ci/scripts/spire-ca.sh
-	

--- a/spire/Makefile
+++ b/spire/Makefile
@@ -1,5 +1,7 @@
 SHELL := /bin/bash
-NAME-SPIRE:=spire
+CUST := development
+RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}')
+NAME-SPIRE := spire-$(CUST)-$(RAND)
 CHART-SPIRE := .
 
 include ../output.mk

--- a/spire/Makefile
+++ b/spire/Makefile
@@ -1,11 +1,8 @@
-SHELL := /bin/bash
-YQCMD := docker run -i docker.greymatter.io/internal/yq:2.4.1
-CUST := $(shell cat ../global.yaml | $(YQCMD) -r '.global.release.customer' )
-RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}')
-NAME-SPIRE := spire-$(CUST)-$(RAND)
-CHART-SPIRE := .
+include ../helpers.mk
 
-include ../output.mk
+NAME-SPIRE-AGENT := spire-agent-$(CUST)-$(RAND)
+NAME-SPIRE-SERVER := spire-server-$(CUST)-$(RAND)
+
 
 wsa-spire:
 	$(eval WAITERSACHECK-SPIRE=$(shell kubectl get sa waiter-sa 2> /dev/null | tail -n +2 | awk '{if ($$1=="waiter-sa") print "--set=global.waiter.service_account.create=false"}'))
@@ -15,16 +12,16 @@ envirionemt-check:
 
 .PHONY: server
 server: wsa-spire
-	helm install $(NAME-SPIRE)-server server $(WAITERSACHECK-SPIRE) -f ../global.yaml
+	helm install $(NAME-SPIRE-SERVER) server $(WAITERSACHECK-SPIRE) -f ../global.yaml
 
 .PHONY: agent
 agent: wsa-spire envirionemt-check
 	@if [ "$(ENVIRONMENT)" == "openshift" ]; then \
-		helm install $(NAME-SPIRE)-agent agent $(WAITERSACHECK-SPIRE) -f ../global.yaml; \
+		helm install $(NAME-SPIRE-AGENT) agent $(WAITERSACHECK-SPIRE) -f ../global.yaml; \
         oc adm policy add-scc-to-user hostaccess system:serviceaccount:spire:agent;\
 		oc adm policy add-scc-to-user privileged system:serviceaccount:spire:agent;\
 	else \
-		helm install $(NAME-SPIRE)-agent agent $(WAITERSACHECK-SPIRE) -f ../global.yaml; \
+		helm install $(NAME-SPIRE-AGENT) agent $(WAITERSACHECK-SPIRE) -f ../global.yaml; \
     fi
 
 clean-spire:
@@ -36,7 +33,8 @@ package-spire: clean-spire
 
 template-spire: package-spire $(BUILD_NUMBER_FILE)
 	mkdir -p $(OUTPUT_PATH)
-	helm template $(NAME-SPIRE) . $(WAITERSACHECK-SPIRE)  -f ../global.yaml > $(OUTPUT_PATH)/helm-$(NAME-SPIRE)$(BN).yaml
+	helm template $(NAME-SPIRE-AGENT) agent $(WAITERSACHECK-SPIRE)  -f ../global.yaml > $(OUTPUT_PATH)/helm-$(NAME-SPIRE-AGENT)$(BN).yaml
+	helm template $(NAME-SPIRE-SERVER) agent $(WAITERSACHECK-SPIRE)  -f ../global.yaml > $(OUTPUT_PATH)/helm-$(NAME-SPIRE-SERVER)$(BN).yaml
 
 .PHONY: spire
 spire: package-spire wsa-spire
@@ -44,8 +42,8 @@ spire: package-spire wsa-spire
 
 .PHONY: remove-spire
 remove-spire:
-	helm uninstall $(shell helm ls | grep agent | awk '{print $$1}')
-	helm uninstall $(shell helm ls | grep server | awk '{print $$1}')
+	helm uninstall $(NAME-SPIRE-AGENT)
+	helm uninstall $(NAME-SPIRE-SERVER)
 
 .PHONY: custom-ca
 custom-ca:

--- a/spire/Makefile
+++ b/spire/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-CUST := development
+CUST := $(shell cat ../global.yaml | docker run -i docker.greymatter.io/internal/yq:2.4.1 -r '.global.release.customer' )
 RAND := $(shell kubectl get configmap greymatter-mesh-identity-$(CUST) -o jsonpath='{.data.rand_identifier}')
 NAME-SPIRE := spire-$(CUST)-$(RAND)
 CHART-SPIRE := .


### PR DESCRIPTION
updates the helm release names that the make files use.


**This has a change to global.yaml**.  a customer field has been added under global.releases.  This is used to create the helm release name as well as an identifier inside a mesh config.

to test install the mesh from the makefiles like normal `make secrets && make install`

do a `helm ls` and you will see all the regular releases in the form `<chart>-<customer>-<random number>`

You should be able to hit the endpoint as you normally do.

To test that the configmap can protect the mesh:

> (if you changed the customer value then replace "development" with that name)

First copy the configmap so we can easily restore it:
 `kc get configmap greymatter-mesh-identity-development -o yaml > mesh-identity.yaml`

Now delete that configmap
`kc delete configmap greymatter-mesh-identity-development`

Run `make uninstall` **This will fail** since the config map is what provides the random sting

Add that configmap back in `kc apply -f mesh-identity.yaml` 

Run `make uninstall`

These commands are also in the readme.



This will help avoid the outage we had last week.