### PR TITLE
add gitbook sync workflow to 2.4

### DIFF
--- a/.github/gitbook-sync-action-readme.md
+++ b/.github/gitbook-sync-action-readme.md
@@ -1,0 +1,67 @@
+# Gitbook Sync Action
+
+This action is used in `release.yaml` and is run after new charts have been released.
+
+<!-- TOC -->
+
+- [Gitbook Sync Action](#gitbook-sync-action)
+  - [Prequisites](#prequisites)
+  - [Process](#process)
+    - [get-current-chart-release-versions](#get-current-chart-release-versions)
+    - [Create_pr](#create_pr)
+  - [Dev Stuff](#dev-stuff)
+    - [Modify Different Branches](#modify-different-branches)
+    - [Deploy Token](#deploy-token)
+
+<!-- /TOC -->
+
+## Prequisites
+
+- github deploy token
+- helm repo with published charts
+- github account, destination repo and source repo (this is source)
+- book.json in destination repo
+
+## Process
+
+### get-current-chart-release-versions
+
+This job will look at a helm repo and parse the info into a file `chart-versions.json` this will be of the form:
+
+```json
+{
+    "chart1_name": "1.2.3",
+    "chart2_name": "2.3.4",
+    "chart3_name": "3.4.5"
+}
+```
+
+This job will pull in **all** charts in that repo.  This allows the next job to be dynamically built out if we add charts.
+
+> Note this workflow does not include dev charts.
+> This job also strips the repo away from the name since `helm search repo x` stores the name as `<local_repo>/<chart_name>` (ex: `greymatter/fabric`).
+> This chart replaces `agent` and `server` with `spire_agent` and `spire_server` as those are the variables used in the gitbook repo.
+
+The chart is passed from one runner to another runner by storing it in an artifact `chart-versions`
+
+### Create_pr
+
+Here is where the super fancy stuff begins.  This job pulls in the destination repo, rebuilds `book.json` using the versions we sourced in the prior job.  If there are any changes the job then creates a branch and pr in the gitbook repo.
+
+## Dev Stuff
+
+Since the first job gets all the charts in the repo we can quickly expand the variables published to gitbook.  To do so, update gitbook with a key, add that key to the `CHARTS` environment variable in the `create_pr` job (space separated array).  If the chart name matches the variable name in gitbook then you're good; otherwise, you'll need to add a `sed` in the `get-current-chart-release-versions` job to massage the `chart-versions.json` artifact.  If the key is in `cts` but not in gitbook any changes will not be reflected in the destination repo pr.
+
+### Modify Different Branches
+
+If you want to use this workflow with a non default branch then set the `BRANCH_TO_UPDATE` to the desired branch in the `create_pr` job.
+
+### Deploy Token
+
+To get this to work you will need to add a deploy token to your pushing repo:
+
+- click your profile in github then settings > developer settings > personal access tokens
+- create a new token with "write:packages" and "repo" and "read:org"
+- copy the generated token
+- in the pushing repo go to settings > secrets > New repository secret and create a secret "deploy_token" and paste in the generated toke from the last step
+- in the github action reference it with `${{ secrets.deploy_token }}.

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -52,6 +52,7 @@ jobs:
           tar -xvf helm-v${helm_version}-linux-amd64.tar.gz
           chmod +s linux-amd64/helm
           sudo mv linux-amd64/helm /usr/local/
+
       - name: Run helm dep up
         run: |
           helm dep up fabric

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -2,8 +2,6 @@ name: Lint and Test Charts
 
 on:
   push:
-    # We don't need to lint on a push to the release branch as this
-    # only happen after a merge
     branches:
       - "!release-*"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ name: Release Charts
 on:
   push:
     branches:
-      - release-2.3
+      - release-*
 
 jobs:
   release:
@@ -37,13 +37,146 @@ jobs:
           echo "$(awk 'NR==1,/name: jwt/{sub(/name: jwt/, "name: jwt-gov")} 1' fabric-gov/Chart.yaml)" > fabric-gov/Chart.yaml
           sed -i -e "s|name: fabric|name: fabric-gov|" -e "s|Grey Matter Fabric|Grey Matter Fabric Gov|" -e "s|/jwt|/jwt-gov|" fabric-gov/Chart.yaml
 
-      - name: Run Grey Matter Charts
+      - name: Release Spire Server and Agent Charts
+        uses: helm/chart-releaser-action@v1.0.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          charts_dir: spire
+
+      - name: Release Grey Matter Charts
         uses: helm/chart-releaser-action@v1.0.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           charts_dir: .
 
+  get-current-chart-release-versions:
+    name: Get current helm chart release versions
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
+      - name: Fetch history
+        run: git fetch --prune --unshallow
 
+      # Install Helm for dependencies
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        id: install-helm
 
+      - name: Get current latest helm releases and build chart-versions.json
+        env:
+          REPO_NAME: greymatter
+          REPO_URL: https://greymatter-io.github.io/helm-charts
+        run: |
+          helm repo add $REPO_NAME $REPO_URL
+          helm repo update
+
+          # Note: this pulls in all charts hosted at the "greymatter" repo we just added
+          helm search repo $REPO_NAME/ -o json | jq '.[] | {(.name): (.version)}' | jq -n '[inputs] | add' >> chart-versions.json
+          sed -i -e "s/$REPO_NAME\///g" chart-versions.json
+          sed -i -e 's/agent/spire_agent/g' chart-versions.json
+          sed -i -e 's/server/spire_server/g' chart-versions.json
+          cat chart-versions.json
+
+      - name: Export chart versions
+        uses: actions/upload-artifact@v2
+        with:
+          name: chart-versions
+          path: chart-versions.json
+  
+  create_pr:
+    name: Create PR to update book.json with new values
+    needs: get-current-chart-release-versions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pull in chart-versions.json from prior step
+        uses: actions/download-artifact@v2
+        with:
+          name: chart-versions
+
+      - name: Update book.json and push to gitbook
+        env:
+          DEPLOY_TOKEN: ${{ secrets.GITBOOK_TOKEN }}
+          TARGET_REPO: "github.com/greymatter-io/gm-gitbook-sync.git"
+          BRANCH_TO_UPDATE: "1.4-beta"
+          CHARTS: "fabric sense edge secrets spire_agent spire_server"
+        run: | 
+          # #### If in the future we have different chart names just add them to the CHARTS environment variable (space separated)
+          # #### The CHARTS environment variable is split into the cts array which is used to export the envars which are used for the sed command
+          # #### These keys must match an already existing key in book.json.  Keys that do not exist
+          # #### will be processed but they will be reflected in any prs to gitbook.
+
+          # ------------Source Desired Envvars from chart-versions artifact ---------------------
+          IFS=', ' read -r -a cts <<< "${CHARTS}"
+          for i in ${cts[@]};do
+              export "${i}=$(cat chart-versions.json | jq -r --arg input ${i} '.[$input]')"
+          done
+
+          # ------------Set up Git and Git Variables ---------------------
+          git config --global user.email "62956126+helm-charts@users.noreply.github.com"
+          git config --global user.name $GITHUB_ACTOR
+          
+          SHORT_DATE="$(date +"%Y-%m-%d")"
+          LONG_DATE="$(date '+%d%m%Y%H%M%S')"
+          BRANCH_NAME=$(echo ${GITHUB_REF}| awk -F/ '{print $3}')
+          NEW_FEATURE_BRANCH_NAME="chart-increment/${BRANCH_NAME}-${LONG_DATE}"
+          commit_message="${SHORT_DATE}: Automatic publish from helm-charts repo.  Incrementing Chart versions in book.json"
+
+          git clone -o upstream https://${GITHUB_ACTOR}:${DEPLOY_TOKEN}@${TARGET_REPO} automation
+          
+          ls
+
+          cd automation
+
+          ls
+
+          git remote add origin https://${GITHUB_ACTOR}:${DEPLOY_TOKEN}@${TARGET_REPO}
+          git checkout ${BRANCH_TO_UPDATE}
+
+          # ------------Business logic---------------------
+          
+          cp book.json old-book.json
+
+          # update book.json with the latest versions from envars 
+          count=1
+          for i in ${cts[@]};do
+              echo "[${count}/${#cts[@]}] --- envar of ${i} is ${!i}"
+              if [[ $count -lt ${#cts[@]} ]]; then
+                  sed -i -e "s|\"${i}\":.*|\"${i}\": \"${!i}\",|" book.json
+              else
+                  sed -i -e "s|\"${i}\":.*|\"${i}\": \"${!i}\"|" book.json
+              fi
+              count=$((count +1))
+          done
+
+          echo "The old book.json: "
+          cat old-book.json
+
+          echo "The new book.json: "
+          cat book.json
+          
+          # This is ratchet but github actions currently exit on any exit code non 0.  diff responds with 1 if there is a difference
+          # This allows us to capture the event where there are no changes since the diff only returns a string if there is a ... diff
+          r=$(diff old-book.json book.json) || true
+          if [[ ! -z $r ]]; then
+            echo "The chart versions have changed. so we will be creating a pr"
+            # ------------Git logic---------------------
+
+            git checkout -b ${NEW_FEATURE_BRANCH_NAME}
+            git remote set-url origin  https://${GITHUB_ACTOR}:${DEPLOY_TOKEN}@${TARGET_REPO}
+            git add book.json
+            git commit -m "${commit_message}"
+            
+            git push --set-upstream origin ${NEW_FEATURE_BRANCH_NAME}
+
+            # This works.  let it be.
+            echo "${DEPLOY_TOKEN}" > token.txt
+            gh auth login --with-token < token.txt
+            gh pr create --title "Bot- Auto Increment Chart Versions" --body "New Helm charts have been released.  This pr increments book.json variables to match current releases" -B ${BRANCH_TO_UPDATE}
+          else
+            echo "There have not been any changes to the versions so we will not update the mesh"
+          fi


### PR DESCRIPTION
brings the same gitbook sync from release-2.3 to release-2.4 but points the target branch to `1.4-beta`