### PR TITLE
fix data type in kafka custom values

### DIFF
--- a/observables/custom-values-files/kafka-values.yaml
+++ b/observables/custom-values-files/kafka-values.yaml
@@ -129,7 +129,7 @@ deleteTopicEnable: false
 heapOpts: -Xmx1024m -Xms1024m
 
 ## The number of messages to accept before forcing a flush of data to disk.
-logFlushIntervalMessages: 10000
+logFlushIntervalMessages: _10000
 
 ## The maximum amount of time a message can sit in a log before we force a flush.
 logFlushIntervalMs: 1000


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

I was attempting install the observables and ran into a a dataType error on https://github.com/bitnami/charts/blob/master/bitnami/kafka/templates/statefulset.yaml#L271. The value needed to be a string, not a float64.

2. What **changes to custom.yaml** are required?

none

3. Have you documented any additional setup steps or configurations options?

n/a

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

After making the change, I was successfully able to run `make observables EKS=false OBSERVABLES_NAMESPACE=default`.
