### PR TITLE
don't template controlAPI securityContext for openshift

### DIFF
--- a/fabric/Chart.yaml
+++ b/fabric/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.3.0
 description: A Helm chart to deploy Grey Matter Fabric
 name: fabric
-version: 3.0.10
+version: 3.0.11
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
@@ -15,7 +15,7 @@ keywords:
 dependencies:
   - name: control-api
     repository: file://./control-api
-    version: '3.0.14'
+    version: '3.0.15'
 
   - name: control
     repository: file://./control

--- a/fabric/control-api/templates/control-api.yaml
+++ b/fabric/control-api/templates/control-api.yaml
@@ -19,11 +19,13 @@ spec:
         deployment: {{ .Values.controlApi.name }}
         greymatter: fabric
     spec:
-      # Security context for openshift, kubernetes and eks is the same.
+      {{- if and .Values.global.environment (ne .Values.global.environment "openshift") }}
+      # Security context for kubernetes and eks is the same.
       securityContext:
         runAsUser: 2000
         runAsGroup: 0
         fsGroup: 2000
+      {{- end }}
       containers:
         - name: {{ .Values.controlApi.name }}
           image: {{ tpl .Values.controlApi.image $ }}
@@ -145,13 +147,13 @@ spec:
       {{- include "sidecar_certs_volumes" . | indent 6 }}
       {{- end }}
 {{ if (lookup "v1" "PersistentVolumeClaim" $.Release.Namespace "control-api-backup-control-api-0") }}
-  volumeClaimTemplates: 
-  - metadata: 
-      name: control-api-backup  
-    spec: 
-      accessModes: 
-        - ReadWriteOnce 
-      resources: 
-        requests: 
+  volumeClaimTemplates:
+  - metadata:
+      name: control-api-backup
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
           storage: {{ .Values.controlApi.pvc.size | default "1Gi" }}
 {{- end }}


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

Closes #910 

When `globals.environment` is set to `openshift`, control api should not add the securityContext.  This adds an `if check` around the securityContext and does not add it when configured for openshift

2. What **changes to custom.yaml** are required?

None

3. Have you documented any additional setup steps or configurations options?

Nothing new here

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

* Run a template (or install) with `globals.environment: eks` and then verify that the securityContext is included with the control-api StatefulSet
* Run a template (or install) with `globals.environment: openshift` and verify that the securityContext is NOT included with the control-api StatefulSet