### PR TITLE
Update the Redis pods to allow commands and arguments to be provided in the values.yaml

### DIFF
--- a/data/Chart.yaml
+++ b/data/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.1.5
 description: A Helm chart to deploy Grey Matter Data
 name: data
-version: 3.0.4
+version: 3.0.5
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
@@ -16,6 +16,6 @@ dependencies:
   # todo: combine into one chart
   - name: gm-data
     repository: file://./gm-data
-    version: '3.0.5'
+    version: '3.0.6'
     alias: data
     condition: global.data.external.enabled

--- a/data/gm-data/Chart.yaml
+++ b/data/gm-data/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 - email: engineering@greyatter.io
   name: greymatter-io
 name: gm-data
-version: 3.0.5
+version: 3.0.6

--- a/data/gm-data/templates/mongo.yaml
+++ b/data/gm-data/templates/mongo.yaml
@@ -18,6 +18,7 @@ spec:
       labels:
         {{ .Values.global.control.cluster_label }}: {{ .Values.mongo.name }}
     spec:
+      {{- if and .Values.global.environment (ne .Values.global.environment "openshift") }}
       {{- if eq .Values.global.environment "eks" }}
       securityContext:
         runAsUser: 2000
@@ -28,6 +29,7 @@ spec:
         runAsUser: 2000
         runAsGroup: 0
         fsGroup: 2000
+      {{- end }}
       {{- end }}
       containers:
       - env:

--- a/fabric/Chart.yaml
+++ b/fabric/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.3.0
 description: A Helm chart to deploy Grey Matter Fabric
 name: fabric
-version: 3.0.14
+version: 3.0.15
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
@@ -23,10 +23,10 @@ dependencies:
 
   - name: jwt
     repository: file://./jwt
-    version: '3.0.4'
+    version: '3.0.5'
 
   - name: redis
     repository: file://./redis
-    version: '1.0.4'
+    version: '1.0.5'
     condition: global.external_redis.disabled
     alias: mesh-redis

--- a/fabric/jwt-gov/Chart.yaml
+++ b/fabric/jwt-gov/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Grey Matter JWT Security Gov
 name: jwt-gov
-version: 3.0.4
+version: 3.0.5
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/fabric/jwt-gov/templates/redis.yaml
+++ b/fabric/jwt-gov/templates/redis.yaml
@@ -27,15 +27,14 @@ spec:
     spec:
       containers:
         - name: redis
-          {{- if and .Values.global.environment (eq .Values.global.environment "openshift") }}
-          image: {{ .Values.redis.openshift.image }}
-          {{- else }}
-          image: {{ .Values.redis.k8s.image }}
+          image: {{ .Values.redis.image }}
+          {{- if .Values.redis.command }}
           command:
-            - 'redis-server'
+{{ toYaml .Values.redis.command | indent 12 }}
+          {{- end }}
+          {{- if .Values.redis.args }}
           args:
-            - '--requirepass'
-            - "$(REDIS_PASSWORD)"
+{{ toYaml .Values.redis.args | indent 12 }}
           {{- end }}
           env:
           - name: REDIS_PASSWORD

--- a/fabric/jwt-gov/values.yaml
+++ b/fabric/jwt-gov/values.yaml
@@ -198,12 +198,12 @@ redis:
   secret:
     secret_name: jwt-redis-password
   password: 'redis'
-  # Redis image to use when global.environment=openshift
-  openshift:
-    image: 'centos/redis-32-centos7'
-  # Redis image to use when global.environment=kubernetes
-  k8s:
-    image: 'redis:3.2'
+  image: bitnami/redis:5.0.12
+  command:
+    - 'redis-server'
+  args:
+    - '--requirepass'
+    - "$(REDIS_PASSWORD)"
   replica_count: 1
   image_pull_policy: IfNotPresent
   # Uses global.image_pull_secret if true

--- a/fabric/jwt/Chart.yaml
+++ b/fabric/jwt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Grey Matter JWT Security
 name: jwt
-version: 3.0.4
+version: 3.0.5
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/fabric/jwt/templates/redis.yaml
+++ b/fabric/jwt/templates/redis.yaml
@@ -27,15 +27,14 @@ spec:
     spec:
       containers:
         - name: redis
-          {{- if and .Values.global.environment (eq .Values.global.environment "openshift") }}
-          image: {{ .Values.redis.openshift.image }}
-          {{- else }}
-          image: {{ .Values.redis.k8s.image }}
+          image: {{ .Values.redis.image }}
+          {{- if .Values.redis.command }}
           command:
-            - 'redis-server'
+{{ toYaml .Values.redis.command | indent 12 }}
+          {{- end }}
+          {{- if .Values.redis.args }}
           args:
-            - '--requirepass'
-            - "$(REDIS_PASSWORD)"
+{{ toYaml .Values.redis.args | indent 12 }}
           {{- end }}
           env:
           {{- include "jwt.envvars" (dict "envvar" .Values.redis.envvars "top" $) | indent 12 }}
@@ -53,6 +52,3 @@ spec:
       schedulerName: default-scheduler
       securityContext: {}
       terminationGracePeriodSeconds: 30
-#  test: false
-#  triggers:
-#    - type: ConfigChange

--- a/fabric/jwt/values.yaml
+++ b/fabric/jwt/values.yaml
@@ -187,12 +187,12 @@ redis:
   # The secret containing the password to configure the environment variable REDIS_PASSWORD
   secret:
     secret_name: jwt-redis-password
-  # Redis image to use when global.environment=openshift
-  openshift:
-    image: 'centos/redis-32-centos7'
-  # Redis image to use when global.environment=kubernetes
-  k8s:
-    image: 'redis:3.2'
+  image: bitnami/redis:5.0.12
+  command:
+    - 'redis-server'
+  args:
+    - '--requirepass'
+    - "$(REDIS_PASSWORD)"
   replica_count: 1
   image_pull_policy: IfNotPresent
   # Uses global.image_pull_secret if true

--- a/fabric/redis/Chart.yaml
+++ b/fabric/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.0.0
 description: A Helm chart to deploy a Redis server to be used by Control API and Catalog
 name: redis
-version: 1.0.4
+version: 1.0.5
 home: https://greymatter.io
 maintainers:
   - name: greymatter-io

--- a/fabric/redis/templates/redis.yaml
+++ b/fabric/redis/templates/redis.yaml
@@ -36,13 +36,12 @@ spec:
         - name: redis
           image: {{ tpl .Values.redis.image $ | quote }}
           imagePullPolicy: {{ .Values.redis.image_pull_policy }}
+        {{- if .Values.redis.command }}
           command:
-            - "redis-server"
+{{ toYaml .Values.redis.command | indent 10 }}
           args:
-            - "--appendonly"
-            - "yes"
-            - "--requirepass"
-            - "$(REDIS_PASSWORD)"
+{{ toYaml .Values.redis.args | indent 10 }}
+        {{- end }}
           env:
           {{- include "envvars" (dict "envvar" .Values.redis.envvars "top" $) | indent 12 }}
         {{- if .Values.redis.resources }}

--- a/fabric/redis/values.yaml
+++ b/fabric/redis/values.yaml
@@ -10,11 +10,20 @@ global:
 
 redis:
   name: mesh-redis
-  image: 'redis:3.2'
+  image: bitnami/redis:5.0.12
   replica_count: 1
   image_pull_policy: IfNotPresent
   # Uses global.image_pull_secret if true
   private_image: false
+  command:
+    - "redis-server"
+  args:
+    - "--appendonly"
+    - "yes"
+    - "--requirepass"
+    - "$(REDIS_PASSWORD)"
+    - "--dir"
+    - "/data"
   secret:
     secret_name: greymatter-mesh-redis-password
   storage:

--- a/test/greymatter_integration_test.go
+++ b/test/greymatter_integration_test.go
@@ -245,7 +245,6 @@ func verifyPods(t *testing.T, kubectlOptions *k8s.KubectlOptions, expectedPodCou
 
 func extractCerts(t *testing.T, kubectlOptions *k8s.KubectlOptions, secret string) {
 	userCertSecret := k8s.GetSecret(t, kubectlOptions, secret)
-
 	err := ioutil.WriteFile("../certs/tls.crt", userCertSecret.Data["tls.crt"], 0644)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

This PR does a few things:
* Updates the version of redis we use for mesh-redis and jwt-redis
* Allows users to specify commands and args for redis rather than having them hard coded in the POD yaml
* Fixes a bug with the Data Mongo instance to remove securityContext if running OpenShift

2. What **changes to custom.yaml** are required?

None

3. Have you documented any additional setup steps or configurations options?

No additional Options

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

The Grey Matter Helm Chart tests have passed.

Note, this PR cannot be applied until after PR #919 has been merged.

