### PR TITLE
set edge ingress DN properly

### DIFF
--- a/global.yaml
+++ b/global.yaml
@@ -11,8 +11,19 @@ global:
   environment: kubernetes
   # Used to configure control and control-api environment variables
   zone: zone-default-zone
-  # domain used to template catalog's apiEndpoint cluster config and configure edge
+
+  # The domain of the Grey Matter installation. If deploying to a known domain
+  # where Grey Matter needs an ingress url, set this to the domain. E.g:
+  # "mydomain.com", when the full url would be https://greymatter.mydomain.com
+  #
+  # When deploying for local development, using localhost:30000 provides an easy
+  # alternative for local ingress
   domain: localhost:30000
+
+  # If deploying to a known domain where Grey Matter needs an ingress url, set
+  # this to the url prefix. E.g.: "greymatter", when the full url would be
+  # https://greymatter.mydomain.com
+  route_url_name:
   # Whether to use consul for service discovery
   consul:
     enabled: false

--- a/secrets/Chart.yaml
+++ b/secrets/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy secrets
 name: secrets
-version: 2.4.0
+version: 2.4.1
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/secrets/templates/_cert-helper.tpl
+++ b/secrets/templates/_cert-helper.tpl
@@ -19,7 +19,11 @@ put a cert ontop of a key.  for use in mongo where it expects this
 {{- end }}
 
 {{- define "secrets.domain" -}}
+  {{- if .Values.global.route_url_name }}
 {{- printf "%s.%s" .Values.global.route_url_name .Values.global.domain -}}
+  {{- else }}
+{{- printf "%s" .Values.global.domain -}}
+  {{- end }}
 {{- end -}}
 
 {{- define "secrets.userDn" -}}


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

When set to auto create the edge ingress certs, it would always create the edge cert with `.Values.global.route_url_name`, and if that value didn't exist it would add an error value to the DN.  This adds a check to the cert creation to check for the value. 

This was only seen on local dev instances where no route_url_name was set.

Closes #921 

2. What **changes to global.yaml** are required?

This PR adds the `route_url_name` to the globals.yaml file, but leave it empty

3. Have you documented any additional setup steps or configurations options?

Yes

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Leave `.Values.global.route_url_name` blank and run `cd secrets; make template-secrets`; find the `greymatter-edge-ingress` secret and copy the value then run:

```
echo "<pasted value>" | base64 -d | openssl x509 -noout -subject
```

Verify the subject is 
```
subject=CN = localhost:30000
```

Then set `.Values.global.route_url_name: test` and run the same commands

```
echo "<pasted value>" | base64 -d | openssl x509 -noout -subject
```

Verify the subject is 
```
subject=CN = test.localhost:30000
```