### PR TITLE
If global certs enabled, sidecar-certs should match

### DIFF
--- a/secrets/Chart.yaml
+++ b/secrets/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart to deploy secrets
 name: secrets
-version: 2.4.1
+version: 2.4.2
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/secrets/templates/global-certs-secret.yaml
+++ b/secrets/templates/global-certs-secret.yaml
@@ -11,7 +11,7 @@ data:
   {{- $cacert := .Files.Get (include "cert" (dict "path" $fromfile "file" "ca.crt") ) }}
   {{- $servercert := .Files.Get (include "cert" (dict "path" $fromfile "file" "server.crt") ) }}
   {{- $serverkey := .Files.Get (include "cert" (dict "path" $fromfile "file" "server.key") ) }}
-  
+
   ca.crt: {{ $cacert | b64enc }}
   server.crt: {{ $servercert | b64enc }}
   server.key: {{ $serverkey | b64enc }}
@@ -20,6 +20,41 @@ data:
   ca.crt: {{ .ca | b64enc }}
   server.crt: {{ .cert | b64enc }}
   server.key: {{ .key | b64enc }}
+{{- end }}
+{{- end }}
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.sidecar.certificates.name }}
+  labels:
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+type: Opaque
+data:
+{{- if .Values.global.global_certs.certificates.from_file.enabled }}
+  {{- $fromfile := $.Values.global.global_certs.certificates.from_file.path }}
+
+  {{- $cacert := .Files.Get (include "cert" (dict "path" $fromfile "file" "ca.crt") ) }}
+  {{- $servercert := .Files.Get (include "cert" (dict "path" $fromfile "file" "server.crt") ) }}
+  {{- $serverkey := .Files.Get (include "cert" (dict "path" $fromfile "file" "server.key") ) }}
+
+  ca.crt: {{ $cacert | b64enc }}
+  ca_b64: {{ $cacert | b64enc | b64enc }}
+  server.crt: {{ $servercert | b64enc }}
+  cert_b64: {{ $servercert | b64enc | b64enc}}
+  server.key: {{ $serverkey | b64enc }}
+  key_b64: {{ $serverkey | b64enc | b64enc}}
+{{- else }}
+{{- with .Values.global.global_certs.certificates }}
+  ca.crt: {{ .ca | b64enc }}
+  ca_b64: {{ .ca | b64enc | b64enc }}
+  server.crt: {{ .cert | b64enc }}
+  cert_b64: {{ .cert | b64enc | b64enc }}
+  server.key: {{ .key | b64enc }}
+  key_b64: {{ .key | b64enc | b64enc }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/secrets/templates/sidecar-secret.yaml
+++ b/secrets/templates/sidecar-secret.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.sidecar.certificates }}
+{{ if and (.Values.sidecar.certificates) (not .Values.global.global_certs.enabled) }}
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

When `global.global_certs.enabled` is set to true, the `sidecar-certs` should match the values provided for the `global_certs`. This fixes that.

2. What **changes to custom.yaml** are required?

none

3. Have you documented any additional setup steps or configurations options?

none needed

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Helm templates verify that the certs are legit.

This PR will need to be rebased after #924 is merged.
