### PR TITLE
Allow the Edge Name to be templated

### DIFF
--- a/edge/Chart.yaml
+++ b/edge/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.1
 description: A Helm chart to deploy Grey Matter Edge
 name: edge
-version: 3.0.5
+version: 3.0.6
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: greymatter-io

--- a/edge/templates/edge-ingress.yaml
+++ b/edge/templates/edge-ingress.yaml
@@ -4,10 +4,11 @@ Defines the edge ingress.  can be reused by passing in annotations, rules, and a
 {{- define "edge-ingress" }}
 {{- $ingress := index . "ingress" }}
 {{- $root := index . "root" }}
+{{- $name := index . "name" }}
 apiVersion: {{ $ingress.apiVersion }}
 kind: Ingress
 metadata:
-  name: edge
+  name: {{ $name }}
   namespace: {{ $root.Release.Namespace }}
   annotations:
 {{ toYaml $ingress.annotations | indent 4 }}
@@ -21,17 +22,17 @@ spec:
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
-  name: edge
+  name: {{ .Values.edge.name }}
   namespace: {{ .Release.Namespace }}
 spec:
   host: {{ include "greymatter.domain" . }}
-  port: 
+  port:
     targetPort: proxy
   tls:
     termination: passthrough
   to:
     kind: Service
-    name: edge
+    name: {{ .Values.edge.name }}
     weight: 100
   wildcardPolicy: None
 {{ include "openshift.route.fix" $ }}
@@ -39,15 +40,17 @@ spec:
 {{- else }}
 
 # Create nginx or voyager ingress using template
-{{- $root := . }}
+{{- $root := $ }}
+{{- $name := .Values.edge.name -}}
 {{- if .Values.edge.ingress.use_voyager }}
 {{- $ingress := .Values.edge.ingress.voyager }}
-{{- include "edge-ingress" (dict "ingress" $ingress "root" $root) }}
+{{- include "edge-ingress" (dict "ingress" $ingress "root" $root "name" $name) }}
 
 {{- else }}
 {{- $ingress := .Values.edge.ingress.nginx}}
-{{- include "edge-ingress" (dict "ingress" $ingress "root" $root) }}
 
-{{- end }} 
+{{- include "edge-ingress" (dict "ingress" $ingress "root" $root "name" $name) }}
+
+{{- end }}
 
 {{- end }}

--- a/edge/templates/edge-service.yaml
+++ b/edge/templates/edge-service.yaml
@@ -1,10 +1,10 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: edge
+  name: {{ .Values.edge.name }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{ .Values.global.control.cluster_label }}: edge
+    {{ .Values.global.control.cluster_label }}: {{ .Values.edge.name }}
 spec:
   ports:
     - name: proxy
@@ -12,6 +12,6 @@ spec:
     - name: metrics
       port: 8081
   selector:
-    {{ .Values.global.control.cluster_label }}: edge
+    {{ .Values.global.control.cluster_label }}: {{ .Values.edge.name }}
   sessionAffinity: None
   type: {{ .Values.edge.ingress.type }}

--- a/edge/templates/edge.yaml
+++ b/edge/templates/edge.yaml
@@ -1,23 +1,23 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: edge
+  name: {{ .Values.edge.name }}
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ include "replicas" (dict "service_values" .Values.edge.replicas "top" $) }}
   selector:
     matchLabels:
-      {{ .Values.global.control.cluster_label }}: edge
+      {{ .Values.global.control.cluster_label }}: {{ .Values.edge.name }}
       deployment: edge
   template:
     metadata:
       labels:
-        {{ .Values.global.control.cluster_label }}: edge
+        {{ .Values.global.control.cluster_label }}: {{ .Values.edge.name }}
         deployment: edge
         greymatter: edge
     spec:
       containers:
-      - name: edge
+      - name: {{ .Values.edge.name }}
         image: {{ tpl .Values.edge.image $ | quote }}
         imagePullPolicy: {{ .Values.edge.image_pull_policy }}
         {{- if .Values.edge.resources }}
@@ -47,7 +47,7 @@ spec:
       {{- if .Values.global.consul.enabled }}
       {{- $data := dict "Values" .Values "ServiceName" "edge" }}
       {{- include "consul.agent" $data | nindent 6 }}
-      {{- end }}      
+      {{- end }}
       imagePullSecrets:
       - name: {{ .Values.global.image_pull_secret }}
       volumes:

--- a/edge/values.yaml
+++ b/edge/values.yaml
@@ -39,6 +39,7 @@ global:
     default_replicas: 3
 
 edge:
+  name: edge
   version: '1.5.1'
   image: 'docker.greymatter.io/release/gm-proxy:{{ tpl $.Values.edge.version $ }}'
   image_pull_policy: IfNotPresent
@@ -50,7 +51,7 @@ edge:
   envvars:
     xds_cluster:
       type: value
-      value: 'edge'
+      value: '{{ .Values.edge.name }}'
     proxy_dynamic:
       type: 'value'
       value: 'true'
@@ -126,9 +127,9 @@ edge:
       # For instance, these values will work for nginx ingress
       apiVersion: extensions/v1beta1
       annotations:
-        nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-        nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-        nginx.ingress.kubernetes.io/backend-protocol: "https"
+        nginx.ingress.kubernetes.io/ssl-passthrough: 'true'
+        nginx.ingress.kubernetes.io/force-ssl-redirect: 'true'
+        nginx.ingress.kubernetes.io/backend-protocol: 'https'
 
       rules:
         - host: development.deciphernow.com


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

The Grey Matter edge chart is one that can be reused in scenarios where we want to add an Edge node to a specific service. As it stands, the edge name is hard coded so it will never work.  We need to allow the edge name to be templated.

2. What **changes to custom.yaml** are required?

n/a

3. Have you documented any additional setup steps or configurations options?

n/a

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

PR tests.
