### PR TITLE
add the ability to specify securityContext for controlapi, redis (jwt…

### DIFF
--- a/fabric/Chart.yaml
+++ b/fabric/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.3.0
 description: A Helm chart to deploy Grey Matter Fabric
 name: fabric
-version: 3.0.16
+version: 3.0.17
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
@@ -15,7 +15,7 @@ keywords:
 dependencies:
   - name: control-api
     repository: file://./control-api
-    version: '3.0.16'
+    version: '3.0.17'
 
   - name: control
     repository: file://./control
@@ -23,10 +23,10 @@ dependencies:
 
   - name: jwt
     repository: file://./jwt
-    version: '3.0.6'
+    version: '3.0.7'
 
   - name: redis
     repository: file://./redis
-    version: '1.0.5'
+    version: '1.0.6'
     condition: global.external_redis.disabled
     alias: mesh-redis

--- a/fabric/control-api/Chart.yaml
+++ b/fabric/control-api/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.5.4
 description: Deploys the Grey Matter 2.0 control-api mesh-wide configuration API
 name: control-api
-version: 3.0.16
+version: 3.0.17
 home: https://greymatter.io
 maintainers:
   - name: greymatter-io

--- a/fabric/control-api/templates/control-api.yaml
+++ b/fabric/control-api/templates/control-api.yaml
@@ -19,12 +19,16 @@ spec:
         deployment: {{ .Values.controlApi.name }}
         greymatter: fabric
     spec:
+      {{- if .Values.controlApi.securityContext  }}
+      securityContext: {{ toYaml .Values.controlApi.securityContext | nindent 8 }}
+      {{- else }}
       {{- if and .Values.global.environment (ne .Values.global.environment "openshift") }}
       # Security context for kubernetes and eks is the same.
       securityContext:
         runAsUser: 2000
         runAsGroup: 0
         fsGroup: 2000
+      {{- end }}
       {{- end }}
       containers:
         - name: {{ .Values.controlApi.name }}

--- a/fabric/control-api/values.yaml
+++ b/fabric/control-api/values.yaml
@@ -93,6 +93,11 @@ controlApi:
       ca: ca.crt
       cert: server.crt
       key: server.key
+  # securityContext specifies the user and groups to use.  This needs needs to be turned on when deploying into openshift
+  securityContext: {}
+    # runAsUser: 2000
+    # runAsGroup: 0
+    # fsGroup: 2000
   envvars:
     gm_control_api_use_tls:
       type: 'value'

--- a/fabric/jwt-gov/Chart.yaml
+++ b/fabric/jwt-gov/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Grey Matter JWT Security Gov
 name: jwt-gov
-version: 3.0.6
+version: 3.0.7
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/fabric/jwt-gov/templates/redis.yaml
+++ b/fabric/jwt-gov/templates/redis.yaml
@@ -25,6 +25,16 @@ spec:
         {{ .Values.global.control.cluster_label }}: {{ .Values.redis.name | default "redis" }}
         deployment: {{ .Values.redis.name | default "redis" }}
     spec:
+      {{- if .Values.redis.securityContext  }}
+      securityContext: {{ toYaml .Values.redis.securityContext | nindent 8 }}
+      {{- else }}
+      {{- if and .Values.global.environment (or (eq .Values.global.environment "eks") (eq .Values.global.environment "openshift")) }}
+      securityContext:
+        runAsUser: 2000
+        runAsGroup: 2000
+        fsGroup: 2000
+      {{- end }}
+      {{- end }}
       containers:
         - name: redis
           image: {{ .Values.redis.image }}
@@ -50,5 +60,4 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
-      securityContext: {}
       terminationGracePeriodSeconds: 30

--- a/fabric/jwt-gov/values.yaml
+++ b/fabric/jwt-gov/values.yaml
@@ -208,6 +208,11 @@ redis:
   image_pull_policy: IfNotPresent
   # Uses global.image_pull_secret if true
   private_image: false
+  # securityContext specifies the user and groups to use.  This needs needs to be turned on when deploying into openshift
+  securityContext: {}
+    # runAsUser: 2001
+    # runAsGroup: 2001
+    # fsGroup: 2001
 
 # Sets default sidecar configurations for all sidecars
 sidecar:

--- a/fabric/jwt/Chart.yaml
+++ b/fabric/jwt/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Grey Matter JWT Security
 name: jwt
-version: 3.0.6
+version: 3.0.7
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/fabric/jwt/templates/redis.yaml
+++ b/fabric/jwt/templates/redis.yaml
@@ -25,6 +25,16 @@ spec:
         deployment: {{ .Values.redis.name }}
         greymatter: fabric
     spec:
+      {{- if .Values.redis.securityContext  }}
+      securityContext: {{ toYaml .Values.redis.securityContext | nindent 8 }}
+      {{- else }}
+      {{- if and .Values.global.environment (or (eq .Values.global.environment "eks") (eq .Values.global.environment "openshift")) }}
+      securityContext:
+        runAsUser: 2000
+        runAsGroup: 2000
+        fsGroup: 2000
+      {{- end }}
+      {{- end }}
       containers:
         - name: redis
           image: {{ .Values.redis.image }}
@@ -50,5 +60,4 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
-      securityContext: {}
       terminationGracePeriodSeconds: 30

--- a/fabric/jwt/values.yaml
+++ b/fabric/jwt/values.yaml
@@ -4,7 +4,7 @@ global:
   # Used as imagePullSecrets value for each subchart
   image_pull_secret: docker.secret
   # Deployment environment, one of "eks", "kuberenetes", or "openshift"
-  environment: openshift
+  environment: kubernetes
   exhibitor:
     replicas: 1
   control:
@@ -204,6 +204,11 @@ redis:
     requests:
       cpu: 100m
       memory: 128Mi
+  # securityContext specifies the user and groups to use.  This needs needs to be turned on when deploying into openshift
+  securityContext: {}
+    # runAsUser: 2001
+    # runAsGroup: 2001
+    # fsGroup: 2001
   envvars:
     redis_password:
       type: secret

--- a/fabric/redis/Chart.yaml
+++ b/fabric/redis/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.0.0
 description: A Helm chart to deploy a Redis server to be used by Control API and Catalog
 name: redis
-version: 1.0.5
+version: 1.0.6
 home: https://greymatter.io
 maintainers:
   - name: greymatter-io

--- a/fabric/redis/templates/redis.yaml
+++ b/fabric/redis/templates/redis.yaml
@@ -22,11 +22,15 @@ spec:
         deployment: {{ .Values.redis.name }}
         greymatter: fabric
     spec:
+      {{- if .Values.redis.securityContext  }}
+      securityContext: {{ toYaml .Values.redis.securityContext | nindent 8 }}
+      {{- else }}
       {{- if and .Values.global.environment (or (eq .Values.global.environment "eks") (eq .Values.global.environment "openshift")) }}
       securityContext:
         runAsUser: 2000
         runAsGroup: 2000
         fsGroup: 2000
+      {{- end }}
       {{- end }}
       {{- if .Values.redis.private_image }}
       imagePullSecrets:

--- a/fabric/redis/values.yaml
+++ b/fabric/redis/values.yaml
@@ -3,7 +3,7 @@
 global:
   image_pull_secret: docker.secret
   # Deployment environment, one of "eks", "kubernetes", or "openshift"
-  environment: eks
+  environment: kubernetes
   control:
     # The label Control uses to find pods to include in the mesh
     cluster_label: greymatter.io/control
@@ -39,6 +39,12 @@ redis:
     requests:
       cpu: 100m
       memory: 128Mi
+  # securityContext specifies the user and groups to use.  This needs needs to be turned on when deploying into openshift
+  securityContext: {}
+    # runAsUser: 2001
+    # runAsGroup: 2001
+    # fsGroup: 2001
+
   envvars:
     redis_password:
       type: secret

--- a/fabric/values.yaml
+++ b/fabric/values.yaml
@@ -191,6 +191,11 @@ control-api:
         ca: ca.crt
         cert: server.crt
         key: server.key
+    # securityContext specifies the user and groups to use.  This needs needs to be turned on when deploying into openshift
+    securityContext: {}
+      # runAsUser: 2000
+      # runAsGroup: 0
+      # fsGroup: 2000
     envvars:
       gm_control_api_use_tls:
         type: 'value'
@@ -284,6 +289,7 @@ control-api:
       greymatter_api_ssl:
         type: value
         value: '{{ not .Values.global.spire.enabled }}'
+
 
 # Services list used to create Grey Matter configuration objects in control-api/config
 services:
@@ -580,3 +586,17 @@ jwt:
         type: secret
         secret: jwt-certs
         key: jwt.key.pem
+  redis:
+    # securityContext specifies the user and groups to use.  This needs needs to be turned on when deploying into openshift
+    securityContext: {} 
+      #runAsUser: 2000
+      #runAsGroup: 2000
+      #fsGroup: 2000
+
+mesh-redis:
+  # securityContext specifies the user and groups to use.  This needs needs to be turned on when deploying into openshift
+  redis:
+    securityContext: {} 
+      #runAsUser: 2000
+      #runAsGroup: 2000
+      #fsGroup: 2000

--- a/sense/slo/templates/postgres.yaml
+++ b/sense/slo/templates/postgres.yaml
@@ -19,12 +19,16 @@ spec:
         {{ .Values.global.control.cluster_label }}: postgres-slo
         greymatter: sense
     spec:
+      {{- if .Values.postgres.securityContext  }}
+      securityContext: {{ toYaml .Values.postgres.securityContext | nindent 8 }}
+      {{- else }}
       {{- if and .Values.global.environment (or (eq .Values.global.environment "eks") (eq .Values.global.environment "openshift")) }}
       # Security context for openshift, kubernetes and eks is the same.
       securityContext:
         runAsUser: 2000
         runAsGroup: 0
         fsGroup: 2000
+      {{- end }}
       {{- end }}
       containers:
       - name: postgres

--- a/sense/slo/values.yaml
+++ b/sense/slo/values.yaml
@@ -188,6 +188,12 @@ postgres:
       ca: ca.pem
       cert: server.crt
       key: server.key
+  # securityContext specifies the user and groups to use.  This needs needs to be turned on when deploying into openshift
+  securityContext: {}
+    # runAsUser: 2001
+    # runAsGroup: 2001
+    # fsGroup: 2001
+
   envvars:
     postgresql_user:
       type: secret

--- a/sense/values.yaml
+++ b/sense/values.yaml
@@ -177,6 +177,11 @@ slo:
         ca: ca.crt
         cert: server.crt
         key: server.key
+    # securityContext specifies the user and groups to use.  This needs needs to be turned on when deploying into openshift
+    securityContext: {}
+      # runAsUser: 2001
+      # runAsGroup: 2001
+      # fsGroup: 2001
     envvars:
       postgresql_user:
         type: secret


### PR DESCRIPTION
Adds the ability to specify specific security contexts instead of using the defaults associated with "openshift" "eks" "kubernetes" etc