### PR TITLE
bump spire chart versions

### DIFF
--- a/spire/Chart.yaml
+++ b/spire/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy Spire
 name: spire
-version: 2.2.6
+version: 2.3.0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
@@ -16,8 +16,8 @@ keywords:
 dependencies:
   - name: agent
     repository: file://./agent
-    version: '2.2.6'
+    version: '2.3.0'
 
   - name: server
     repository: file://./server
-    version: '2.2.6'
+    version: '2.3.0'

--- a/spire/agent/Chart.yaml
+++ b/spire/agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy the Spire Agent
 name: agent
-version: 2.2.6
+version: 2.3.0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:

--- a/spire/server/Chart.yaml
+++ b/spire/server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: 1.2.0
 description: A Helm chart to deploy the Spire Server
 name: server
-version: 2.2.6
+version: 2.3.0
 home: https://greymatter.io
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:


### PR DESCRIPTION
Bumps the spire chart versions in an attempt to have them redeploy properly to the helm repo