### PR TITLE
Template the domain for an ingress object the same as an OCP route object

### DIFF
--- a/edge/Chart.yaml
+++ b/edge/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.1
 description: A Helm chart to deploy Grey Matter Edge
 name: edge
-version: 3.0.6
+version: 3.0.7
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: greymatter-io

--- a/edge/templates/_domain.tpl
+++ b/edge/templates/_domain.tpl
@@ -1,7 +1,15 @@
 {{- define "greymatter.domain" }}
-    {{- if .Values.global.remove_namespace_from_url  }}
-{{- .Values.global.route_url_name }}.{{ .Values.global.domain }}
+    {{- if (contains ":" .Values.global.domain) -}}
+        {{ (split ":" .Values.global.domain)._0 }}
     {{- else }}
-{{- .Values.global.route_url_name }}.{{ .Release.Namespace }}.{{ .Values.global.domain }}
+        {{- if .Values.global.route_url_name }}
+            {{- if .Values.global.remove_namespace_from_url  }}
+    {{- .Values.global.route_url_name }}.{{ .Values.global.domain }}
+            {{- else }}
+    {{- .Values.global.route_url_name }}.{{ .Release.Namespace }}.{{ .Values.global.domain }}
+            {{- end }}
+        {{- else }}
+    {{- .Values.global.domain -}}
+        {{- end }}
     {{- end }}
 {{- end }}

--- a/edge/templates/edge-ingress.yaml
+++ b/edge/templates/edge-ingress.yaml
@@ -14,7 +14,7 @@ metadata:
 {{ toYaml $ingress.annotations | indent 4 }}
 spec:
   rules:
-{{ toYaml $ingress.rules | indent 4 }}
+{{ tpl (toYaml $ingress.rules) $root | indent 4 }}
 {{- end }}
 
 

--- a/edge/values.yaml
+++ b/edge/values.yaml
@@ -115,13 +115,13 @@ edge:
             port: '80'
             nodePort: '30001'
             backend:
-              serviceName: edge
+              serviceName: '{{ .Values.edge.name }}'
               servicePort: 10808
         - tcp:
             port: '443'
             nodePort: '30000'
             backend:
-              serviceName: edge
+              serviceName: '{{ .Values.edge.name }}'
               servicePort: 10808
     nginx:
       # For instance, these values will work for nginx ingress
@@ -132,10 +132,10 @@ edge:
         nginx.ingress.kubernetes.io/backend-protocol: 'https'
 
       rules:
-        - host: development.deciphernow.com
+        - host: '{{ include "greymatter.domain" $ }}'
           http:
             paths:
               - path: /
                 backend:
-                  serviceName: edge
+                  serviceName: '{{ .Values.edge.name }}'
                   servicePort: 10808


### PR DESCRIPTION
**Please provide enough information so that others can review your pull request:**

fixes #932

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

The existing code doesn't template the proper <route>.<domain> when building the Nginx ingress object. The code now uses the same `domain` template as the OCP route object.

2. What **changes to custom.yaml** are required?

None

3. Have you documented any additional setup steps or configurations options?

No other steps needed.

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Run the following command to verify:

```
➜  helm-charts git:(fix/932) ✗ helm template edge --set global.route_url_name=mesh --set global.environment=kubernetes --set global.domain=greymatter.io
.
.
.
.
---
# Source: edge/templates/edge-ingress.yaml
# Create nginx or voyager ingress using template
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: edge
  namespace: public
  annotations:
    nginx.ingress.kubernetes.io/backend-protocol: https
    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
spec:
  rules:
    - host: 'mesh.greymatter.io'
      http:
        paths:
        - backend:
            serviceName: edge
            servicePort: 10808
          path: /
```
