### PR TITLE
Increment edge chart.yaml to kick new release

### DIFF
--- a/edge/Chart.yaml
+++ b/edge/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.5.1
 description: A Helm chart to deploy Grey Matter Edge
 name: edge
-version: 3.0.7
+version: 3.0.8
 icon: https://s3.amazonaws.com/decipher-public/grey-matter/branding/grey-matter-mark-rgb.png
 maintainers:
   - name: greymatter-io


### PR DESCRIPTION
the 3.0.7 did not release failed to release using cr 1.2.1
we reverted to cr 1.0.0 however that did not release because it did not detect a change in the edge chart.
incrementing the chart.yaml version to 3.0.8 to force a re release

**Please provide enough information so that others can review your pull request:**

1. Explain the **details** for making this change. What existing problem does the pull request solve? If it resolves an existing issue, be sure to use a Github [keyword](https://help.github.com/en/articles/closing-issues-using-keywords) to automatically close it.

<br/><br/>

2. What **changes to custom.yaml** are required?

<br/><br/>

3. Have you documented any additional setup steps or configurations options?

<br/><br/>

4. Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

<br/><br/>
